### PR TITLE
Improve identity resolution for Wolvesville ledgers and missions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,9 +7,11 @@ import logging
 import math
 import json
 import os
+import secrets
 from datetime import datetime, timezone
 from io import BytesIO
 from typing import List, Dict, Any, Optional
+from urllib.parse import quote_plus
 
 # Librerie di terze parti
 import requests
@@ -30,6 +32,7 @@ from aiogram.fsm.state import StatesGroup, State
 from aiogram.fsm.context import FSMContext
 from aiogram.dispatcher.middlewares.base import BaseMiddleware
 from services.notification_service import EnhancedNotificationService, NotificationType
+from services.db_manager import MongoManager
 from config import (
     TOKEN,
     WOLVESVILLE_API_KEY,
@@ -87,6 +90,148 @@ def maybe_log_public_ip() -> None:
     if public_ip:
         logger.info("IP pubblico del bot: %s", public_ip)
 
+
+def format_telegram_username(username: Optional[str]) -> str:
+    """Restituisce uno username Telegram formattato con @ oppure un segnaposto."""
+
+    if not username:
+        return "—"
+    cleaned = username.strip()
+    if not cleaned:
+        return "—"
+    return cleaned if cleaned.startswith("@") else f"@{cleaned}"
+
+
+def build_profile_snapshot(profile: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Estrae un sottoinsieme sicuro dei dati del profilo per i log."""
+
+    if not profile:
+        return None
+
+    snapshot: Dict[str, Any] = {
+        "telegram_id": profile.get("telegram_id"),
+        "telegram_username": profile.get("telegram_username"),
+        "game_username": profile.get("game_username"),
+        "wolvesville_id": profile.get("wolvesville_id"),
+    }
+
+    if profile.get("updated_at"):
+        snapshot["updated_at"] = profile.get("updated_at")
+    if profile.get("created_at"):
+        snapshot["created_at"] = profile.get("created_at")
+
+    verification = profile.get("verification")
+    if isinstance(verification, dict):
+        snapshot["verification"] = {
+            key: verification.get(key)
+            for key in ("status", "verified_at", "method", "code")
+            if verification.get(key) is not None
+        }
+
+    return snapshot
+
+
+async def resolve_member_identity(username: Optional[str]) -> Dict[str, Any]:
+    """Risolvi uno username di gioco in base al profilo collegato."""
+
+    raw_username = username or ""
+    cleaned_username = raw_username.strip()
+
+    identity: Dict[str, Any] = {
+        "input_username": username,
+        "original_username": cleaned_username or None,
+        "resolved_username": cleaned_username or None,
+        "telegram_id": None,
+        "telegram_username": None,
+        "match": None,
+        "profile": None,
+        "profile_snapshot": None,
+    }
+
+    if not cleaned_username:
+        return identity
+
+    try:
+        resolution = await db_manager.resolve_profile_by_game_alias(cleaned_username)
+    except Exception as exc:  # pragma: no cover - log diagnostico
+        logger.warning(
+            "Impossibile risolvere il profilo per %s: %s",
+            cleaned_username,
+            exc,
+        )
+        return identity
+
+    if not resolution:
+        return identity
+
+    profile = resolution.get("profile") or {}
+    resolved_username = resolution.get("resolved_username") or cleaned_username
+
+    identity.update(
+        {
+            "resolved_username": resolved_username,
+            "match": resolution.get("match"),
+            "telegram_id": profile.get("telegram_id"),
+            "telegram_username": profile.get("telegram_username"),
+            "profile": profile,
+            "profile_snapshot": build_profile_snapshot(profile),
+        }
+    )
+
+    return identity
+
+
+async def ensure_telegram_profile_synced(user: Optional[types.User]) -> None:
+    """Allinea il profilo Telegram con il database e notifica eventuali cambi username."""
+
+    if user is None:
+        return
+
+    full_name_parts = [user.first_name or "", user.last_name or ""]
+    full_name = " ".join(part for part in full_name_parts if part).strip() or None
+
+    try:
+        result = await db_manager.sync_telegram_metadata(
+            user.id,
+            telegram_username=user.username,
+            full_name=full_name,
+        )
+    except Exception as exc:  # pragma: no cover - logging di sicurezza
+        logger.warning(
+            "Impossibile aggiornare il profilo Telegram per %s: %s",
+            getattr(user, "id", "?"),
+            exc,
+        )
+        return
+
+    if not result or result.get("created"):
+        return
+
+    if (
+        result.get("telegram_username_changed")
+        and notification_service
+        and result.get("profile")
+    ):
+        profile = result["profile"]
+        game_username = profile.get("game_username")
+        if not game_username:
+            return
+        old_username = format_telegram_username(result.get("previous_telegram_username"))
+        new_username = format_telegram_username(profile.get("telegram_username"))
+        message = (
+            "♻️ <b>Aggiornamento username Telegram</b>\n\n"
+            f"🎮 <b>Giocatore:</b> {game_username}\n"
+            f"🆔 <b>Telegram ID:</b> <code>{profile.get('telegram_id')}</code>\n"
+            f"🔁 <b>Username:</b> {old_username} → {new_username}"
+        )
+        try:
+            await notification_service.send_admin_notification(
+                message,
+                notification_type=NotificationType.INFO,
+            )
+        except Exception as exc:  # pragma: no cover - log esterno
+            logger.warning("Notifica cambio username Telegram fallita: %s", exc)
+
 # =============================================================================
 # CONFIGURAZIONE DI MONGODB
 # =============================================================================
@@ -95,9 +240,9 @@ DATABASE_NAME = "Wolvesville"
 USERS_COLLECTION = "users"
 
 mongo_client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_URI, tlsAllowInvalidCertificates=True)
-db = mongo_client[DATABASE_NAME]
-users_col = db[USERS_COLLECTION]
-processed_ledger_col = db["processed_ledger"]
+db_manager = MongoManager(mongo_client, DATABASE_NAME)
+
+notification_service: Optional[EnhancedNotificationService] = None
 
 # Tempo di reset per considerare solo le donazioni future
 RESET_TIME = datetime.now(timezone.utc)
@@ -113,6 +258,10 @@ class LoggingMiddleware(BaseMiddleware):
             user_id = event.from_user.id
             text = event.text if event.text else "<Non testuale>"
             logger.info(f"Messaggio ricevuto | Chat ID: {chat_id} | Thread ID: {thread_id} | Utente ID: {user_id} | Testo: {text}")
+            try:
+                await ensure_telegram_profile_synced(event.from_user)
+            except Exception as exc:  # pragma: no cover - evitare crash middleware
+                logger.warning("Sync profilo Telegram fallita per %s: %s", user_id, exc)
         return await handler(event, data)
 
 class UpdateLoggingMiddleware(BaseMiddleware):
@@ -131,26 +280,24 @@ async def clean_duplicate_users():
     Rimuove utenti duplicati dal database mantenendo solo uno per username.
     """
     try:
-        # Trova tutti gli username duplicati
-        pipeline = [
-            {"$group": {"_id": "$username", "count": {"$sum": 1}, "docs": {"$push": "$_id"}}},
-            {"$match": {"count": {"$gt": 1}}}
-        ]
+        removed_info = await db_manager.remove_duplicate_users()
+        total_removed = sum(item.get("removed", 0) for item in removed_info)
 
-        duplicates = await users_col.aggregate(pipeline).to_list(length=None)
+        for item in removed_info:
+            username = item.get("username", "sconosciuto")
+            removed = item.get("removed", 0)
+            removed_ids = item.get("removed_ids", [])
+            logger.info(
+                "Eliminati %s duplicati per %s (documenti rimossi: %s)",
+                removed,
+                username,
+                removed_ids,
+            )
 
-        for duplicate in duplicates:
-            username = duplicate["_id"]
-            doc_ids = duplicate["docs"]
-
-            # Mantieni solo il primo documento, elimina gli altri
-            docs_to_delete = doc_ids[1:]  # Salta il primo
-
-            for doc_id in docs_to_delete:
-                await users_col.delete_one({"_id": doc_id})
-                logger.info(f"Eliminato documento duplicato per {username}")
-
-        logger.info(f"Pulizia duplicati completata. Eliminati {len(duplicates)} duplicati.")
+        logger.info(
+            "Pulizia duplicati completata. Eliminati %s duplicati.",
+            total_removed,
+        )
 
     except Exception as e:
         logger.error(f"Errore durante pulizia duplicati: {e}")
@@ -180,7 +327,7 @@ async def check_clan_departures():
                 current_usernames.add(username)
 
         # Ottieni tutti gli utenti nel database
-        db_users = await users_col.find({}).to_list(length=None)
+        db_users = await db_manager.list_users()
 
         users_removed = 0
         debt_notifications = 0
@@ -226,8 +373,8 @@ async def check_clan_departures():
 
             else:
                 # Nessun debito, elimina dal database
-                result = await users_col.delete_one({"username": username})
-                if result.deleted_count > 0:
+                removed = await db_manager.remove_user_by_username(username)
+                if removed > 0:
                     users_removed += 1
                     logger.info(f"Utente {username} rimosso dal database (nessun debito)")
 
@@ -258,15 +405,8 @@ async def prepopulate_users():
                 username = member.get("username")
                 if username:
                     # UPSERT con controllo duplicati migliorato
-                    result = await users_col.update_one(
-                        {"username": username},
-                        {
-                            "$setOnInsert": {"donazioni": {"Oro": 0, "Gem": 0}},
-                            "$set": {"username": username}  # Assicura che username sia sempre presente
-                        },
-                        upsert=True
-                    )
-                    if result.upserted_id:
+                    inserted = await db_manager.ensure_user(username)
+                    if inserted:
                         logger.info(f"Utente {username} pre-popolato con bilancio 0.")
 
 
@@ -277,19 +417,7 @@ async def update_user_balance(username: str, currency: str, amount: int):
     mentre se è "gem" viene usato "Gem". In questo modo si evita di creare campi
     duplicati (es. "Gold") e si mantiene il DB con soli due campi: Oro e Gem.
     """
-    if currency.lower() == "gold":
-        normalized_currency = "Oro"
-    elif currency.lower() == "gem":
-        normalized_currency = "Gem"
-    else:
-        normalized_currency = currency.capitalize()
-
-    field = f"donazioni.{normalized_currency}"
-    await users_col.update_one(
-        {"username": username},
-        {"$inc": {field: amount}, "$setOnInsert": {"username": username}},
-        upsert=True
-    )
+    normalized_currency = await db_manager.update_user_balance(username, currency, amount)
     logger.info(f"Aggiornato bilancio per {username}: {normalized_currency} += {amount}")
 
 
@@ -317,8 +445,7 @@ async def process_ledger():
                     continue
 
                 # Verifica se abbiamo già processato questo record
-                already_processed = await processed_ledger_col.find_one({"_id": record_id})
-                if already_processed:
+                if await db_manager.has_processed_ledger(record_id):
                     # Significa che l'abbiamo già gestito, quindi skip
                     continue
 
@@ -329,31 +456,185 @@ async def process_ledger():
 
                 # Se c'è un username e c'è effettivamente una donazione > 0
                 if username and (gold_amount > 0 or gems_amount > 0):
+                    identity = await resolve_member_identity(username)
+                    resolved_username = identity.get("resolved_username")
+                    if not resolved_username:
+                        logger.warning(
+                            "Record ledger %s ignorato: username non valido (%s)",
+                            record_id,
+                            username,
+                        )
+                        continue
+
+                    original_username = identity.get("original_username") or username
+                    if (
+                        identity.get("match") == "history"
+                        and original_username
+                        and original_username != resolved_username
+                    ):
+                        logger.info(
+                            "Ledger: risolto alias %s → %s (record %s)",
+                            original_username,
+                            resolved_username,
+                            record_id,
+                        )
+
                     # Aggiungi gold a Oro
                     if gold_amount > 0:
-                        await update_user_balance(username, "Oro", gold_amount)
+                        await update_user_balance(resolved_username, "Oro", gold_amount)
                     # Aggiungi gems
                     if gems_amount > 0:
-                        await update_user_balance(username, "Gem", gems_amount)
+                        await update_user_balance(resolved_username, "Gem", gems_amount)
+
+                    await db_manager.log_donation(
+                        record_id,
+                        resolved_username,
+                        gold_amount,
+                        gems_amount,
+                        raw_record=record,
+                        telegram_id=identity.get("telegram_id"),
+                        telegram_username=identity.get("telegram_username"),
+                        profile_snapshot=identity.get("profile_snapshot"),
+                        original_username=original_username,
+                        match_source=identity.get("match"),
+                    )
 
                 # Segna questo record come "già processato"
-                await processed_ledger_col.insert_one({"_id": record_id})
+                await db_manager.mark_ledger_processed(record_id, raw_record=record)
 
-async def process_mission(participants: List[str], mission_type: str):
-    """
-    Processa le missioni e applica il costo appropriato (deduzione dal bilancio) in base al tipo di missione.
-    """
-    if mission_type == "Gold":
+async def process_mission(
+    participants: List[str],
+    mission_type: str,
+    *,
+    mission_id: Optional[str] = None,
+    outcome: str = "processed",
+    source: str = "manual",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Processa una missione, applica i costi e registra la partecipazione nel database."""
+
+    if not participants:
+        logger.info("Processo missione %s saltato: nessun partecipante fornito.", mission_type)
+        return None
+
+    mission_type = mission_type or "Unknown"
+    mission_type_lower = mission_type.lower()
+
+    resolved_identities: List[Dict[str, Any]] = []
+    alias_resolved_count = 0
+    for participant in participants:
+        identity = await resolve_member_identity(participant)
+        resolved_username = identity.get("resolved_username")
+        if not resolved_username:
+            logger.warning(
+                "Missione %s: ignorato partecipante senza username valido (%s)",
+                mission_type,
+                participant,
+            )
+            continue
+        if (
+            identity.get("match") == "history"
+            and identity.get("original_username")
+            and identity.get("original_username") != resolved_username
+        ):
+            alias_resolved_count += 1
+            logger.info(
+                "Missione %s: alias risolto %s → %s",
+                mission_type,
+                identity.get("original_username"),
+                resolved_username,
+            )
+        resolved_identities.append(identity)
+
+    if not resolved_identities:
+        logger.info(
+            "Processo missione %s saltato: nessun partecipante risolto.", mission_type
+        )
+        return None
+
+    participant_count = len(resolved_identities)
+    cost = 0
+    currency_key = mission_type
+
+    if mission_type_lower == "gold":
         cost = 500
-        for user in participants:
-            await update_user_balance(user, "Oro", -cost)
-        logger.info(f"Applicato costo di {cost} Oro a {len(participants)} partecipanti (missione Gold).")
-    elif mission_type == "Gem":
-        num = len(participants)
-        cost = 150 if 5 <= num <= 7 else 140 if num > 7 else 0
-        for user in participants:
-            await update_user_balance(user, "Gem", -cost)
-        logger.info(f"Applicato costo di {cost} Gem a {len(participants)} partecipanti (missione Gem).")
+        currency_key = "Gold"
+    elif mission_type_lower == "gem":
+        if participant_count > 7:
+            cost = 140
+        elif 5 <= participant_count <= 7:
+            cost = 150
+        else:
+            cost = 0
+        currency_key = "Gem"
+
+    if cost != 0:
+        for identity in resolved_identities:
+            await update_user_balance(identity["resolved_username"], currency_key, -cost)
+        logger.info(
+            "Applicato costo di %s %s a %s partecipanti (missione %s).",
+            cost,
+            "Oro" if mission_type_lower == "gold" else "Gem",
+            participant_count,
+            mission_type,
+        )
+        if alias_resolved_count:
+            logger.info(
+                "Missione %s: %s partecipanti provenivano da alias storici.",
+                mission_type,
+                alias_resolved_count,
+            )
+    else:
+        logger.info(
+            "Registrata missione %s senza costi aggiuntivi per %s partecipanti.",
+            mission_type,
+            participant_count,
+        )
+
+    metadata_payload = dict(metadata or {})
+    metadata_payload.setdefault("participants_count", participant_count)
+    metadata_payload.setdefault("cost_applied", cost)
+    metadata_payload["resolved_participants_count"] = participant_count
+    metadata_payload["alias_resolutions"] = alias_resolved_count
+    metadata_payload["linked_participants"] = sum(
+        1 for identity in resolved_identities if identity.get("telegram_id")
+    )
+
+    participant_entries: List[Dict[str, Any]] = []
+    for identity in resolved_identities:
+        entry: Dict[str, Any] = {
+            "username": identity.get("resolved_username"),
+            "original_username": identity.get("original_username"),
+        }
+        if identity.get("telegram_id") is not None:
+            entry["telegram_id"] = identity.get("telegram_id")
+        if identity.get("telegram_username"):
+            entry["telegram_username"] = identity.get("telegram_username")
+        if identity.get("match"):
+            entry["match"] = identity.get("match")
+        if identity.get("profile_snapshot"):
+            entry["profile_snapshot"] = identity.get("profile_snapshot")
+        participant_entries.append(entry)
+
+    event_id = await db_manager.log_mission_participation(
+        mission_id,
+        mission_type,
+        participant_entries,
+        cost_per_participant=cost,
+        outcome=outcome,
+        source=source,
+        metadata=metadata_payload,
+    )
+
+    if event_id:
+        logger.info(
+            "Registrata partecipazione missione %s (event_id=%s) con %s partecipanti.",
+            mission_id or "manual",
+            event_id,
+            participant_count,
+        )
+
+    return event_id
 
 async def process_active_mission_auto():
     """
@@ -383,19 +664,48 @@ async def process_active_mission_auto():
         logger.error("Missione attiva priva di id o tierStartTime.")
         return
 
-    processed_active_col = db["processed_active_missions"]
-    already_processed = await processed_active_col.find_one({"_id": mission_id})
-    if already_processed:
+    if await db_manager.has_processed_active_mission(mission_id):
         logger.info(f"Missione {mission_id} già processata. Nessuna operazione eseguita.")
         return
 
     # Partecipanti a livello top
     participants = active_data.get("participants", [])
-    usernames = [p.get("username") for p in participants if p.get("username")]
-    count = len(usernames)
-    if not usernames:
+    raw_usernames = [p.get("username") for p in participants if p.get("username")]
+    if not raw_usernames:
         logger.info("Nessun partecipante trovato nella missione attiva.")
         return
+
+    resolved_identities: List[Dict[str, Any]] = []
+    alias_resolved_count = 0
+    for username in raw_usernames:
+        identity = await resolve_member_identity(username)
+        resolved_username = identity.get("resolved_username")
+        if not resolved_username:
+            logger.warning(
+                "Missione attiva %s: ignorato username non valido (%s)",
+                mission_id,
+                username,
+            )
+            continue
+        if (
+            identity.get("match") == "history"
+            and identity.get("original_username")
+            and identity.get("original_username") != resolved_username
+        ):
+            alias_resolved_count += 1
+            logger.info(
+                "Missione attiva %s: alias risolto %s → %s",
+                mission_id,
+                identity.get("original_username"),
+                resolved_username,
+            )
+        resolved_identities.append(identity)
+
+    if not resolved_identities:
+        logger.info("Missione %s: nessun partecipante valido dopo la risoluzione.", mission_id)
+        return
+
+    count = len(resolved_identities)
 
     mission_type = "Gem" if quest.get("purchasableWithGems", False) else "Gold"
     if mission_type == "Gold":
@@ -408,12 +718,69 @@ async def process_active_mission_auto():
         else:
             cost = 0
 
-    for username in usernames:
-        await update_user_balance(username, mission_type, -cost)
-        logger.info(f"Dedotto {cost} {('Oro' if mission_type=='Gold' else 'Gem')} per {username} nella missione {mission_id}")
+    for identity in resolved_identities:
+        await update_user_balance(identity["resolved_username"], mission_type, -cost)
+        log_name = identity.get("resolved_username")
+        original = identity.get("original_username")
+        if original and original != log_name:
+            logger.info(
+                "Dedotto %s %s per %s (alias %s) nella missione %s",
+                cost,
+                "Oro" if mission_type == "Gold" else "Gem",
+                log_name,
+                original,
+                mission_id,
+            )
+        else:
+            logger.info(
+                "Dedotto %s %s per %s nella missione %s",
+                cost,
+                "Oro" if mission_type == "Gold" else "Gem",
+                log_name,
+                mission_id,
+            )
 
-    await processed_active_col.insert_one({"_id": mission_id, "tierStartTime": tier_start_time})
-    logger.info(f"Missione {mission_id} processata e registrata.")
+    metadata = {
+        "tier_start_time": tier_start_time,
+        "participant_count": count,
+        "alias_resolutions": alias_resolved_count,
+        "linked_participants": sum(
+            1 for identity in resolved_identities if identity.get("telegram_id")
+        ),
+    }
+
+    participant_entries: List[Dict[str, Any]] = []
+    for identity in resolved_identities:
+        entry: Dict[str, Any] = {
+            "username": identity.get("resolved_username"),
+            "original_username": identity.get("original_username"),
+        }
+        if identity.get("telegram_id") is not None:
+            entry["telegram_id"] = identity.get("telegram_id")
+        if identity.get("telegram_username"):
+            entry["telegram_username"] = identity.get("telegram_username")
+        if identity.get("match"):
+            entry["match"] = identity.get("match")
+        if identity.get("profile_snapshot"):
+            entry["profile_snapshot"] = identity.get("profile_snapshot")
+        participant_entries.append(entry)
+
+    event_id = await db_manager.log_mission_participation(
+        mission_id,
+        mission_type,
+        participant_entries,
+        cost_per_participant=cost,
+        outcome="auto_processed",
+        source="active_mission",
+        metadata=metadata,
+    )
+
+    await db_manager.mark_active_mission_processed(mission_id, tier_start_time)
+    logger.info(
+        "Missione %s processata e registrata (event_id=%s).",
+        mission_id,
+        event_id,
+    )
 
 # =============================================================================
 # FUNZIONI HELPER PER FSM E GESTIONE MESSAGGI DI MODIFICA
@@ -438,6 +805,11 @@ class ModifyStates(StatesGroup):
 class PlayerStates(StatesGroup):
     MEMBER_CHECK = State()
     PROFILE_SEARCH = State()
+
+
+class LinkStates(StatesGroup):
+    WAITING_GAME_USERNAME = State()
+    WAITING_VERIFICATION = State()
 
 # =============================================================================
 # DEFINIZIONE DELLE CALLBACK DATA (per il flusso menu, modifica e missione)
@@ -575,6 +947,90 @@ async def get_best_resolution_url(url_base: str) -> str:
                 return url_2x
 
     return url_base
+
+
+def generate_verification_code() -> str:
+    """Genera un codice casuale utilizzato per la verifica dell'identità."""
+
+    return secrets.token_hex(3).upper()
+
+
+def build_verification_keyboard() -> InlineKeyboardMarkup:
+    """Crea la tastiera inline condivisa per la verifica del profilo."""
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="✅ Ho aggiornato il profilo",
+                    callback_data="link_verify",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="❌ Annulla",
+                    callback_data="link_cancel",
+                )
+            ],
+        ]
+    )
+
+
+async def fetch_player_by_username(username: str) -> Optional[Dict[str, Any]]:
+    """Recupera le informazioni del giocatore tramite username."""
+
+    if not username:
+        return None
+    query = quote_plus(username.strip())
+    url = f"https://api.wolvesville.com/players/search?username={query}"
+    headers = {
+        "Authorization": f"Bot {WOLVESVILLE_API_KEY}",
+        "Accept": "application/json",
+    }
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                if response.status != 200:
+                    logger.warning(
+                        "Impossibile recuperare il giocatore %s (status %s)",
+                        username,
+                        response.status,
+                    )
+                    return None
+                payload = await response.json()
+    except Exception as exc:
+        logger.error("Errore durante la ricerca del giocatore %s: %s", username, exc)
+        return None
+
+    if isinstance(payload, list):
+        return payload[0] if payload else None
+    return payload
+
+
+async def fetch_player_by_id(player_id: str) -> Optional[Dict[str, Any]]:
+    """Recupera un giocatore tramite ID Wolvesville."""
+
+    if not player_id:
+        return None
+    url = f"https://api.wolvesville.com/players/{player_id}"
+    headers = {
+        "Authorization": f"Bot {WOLVESVILLE_API_KEY}",
+        "Accept": "application/json",
+    }
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                if response.status != 200:
+                    logger.warning(
+                        "Impossibile recuperare il giocatore con ID %s (status %s)",
+                        player_id,
+                        response.status,
+                    )
+                    return None
+                return await response.json()
+    except Exception as exc:
+        logger.error("Errore durante il recupero del giocatore %s: %s", player_id, exc)
+        return None
 
 def chunk_list(items, chunk_size=6):
     """
@@ -1080,6 +1536,247 @@ async def scheduled_mission_skin():
 async def send_and_log(text: str, chat_id: int, reply_markup: types.InlineKeyboardMarkup = None):
     logger.info(f"Sending message to {chat_id}: {text}")
     return await bot.send_message(chat_id=chat_id, text=text, reply_markup=reply_markup)
+
+# =============================================================================
+# COMANDO /COLLEGA PROFILO
+# =============================================================================
+@dp.message(Command("collega"))
+async def link_profile_command(message: types.Message, state: FSMContext):
+    """Avvia il flusso di collegamento tra Telegram e Wolvesville."""
+
+    if message.chat.type != "private":
+        await message.answer(
+            "🔒 Per motivi di sicurezza esegui /collega in chat privata con il bot."
+        )
+        return
+
+    await state.clear()
+    await ensure_telegram_profile_synced(message.from_user)
+
+    profile = await db_manager.get_profile_by_telegram_id(message.from_user.id)
+    lines = [
+        "🔗 <b>Collegamento profilo Wolvesville</b>",
+        "Inviami ora il tuo username di gioco esattamente come appare in Wolvesville.",
+    ]
+    if profile and profile.get("game_username"):
+        lines.append(
+            f"Attualmente risulti collegato a <b>{profile['game_username']}</b>."
+        )
+    lines.append(
+        "Se il tuo username è cambiato ripeti questa procedura per mantenere il database allineato."
+    )
+
+    await message.answer("\n\n".join(lines))
+    await state.set_state(LinkStates.WAITING_GAME_USERNAME)
+
+
+@dp.message(LinkStates.WAITING_GAME_USERNAME)
+async def receive_game_username(message: types.Message, state: FSMContext):
+    """Riceve lo username Wolvesville e prepara la verifica."""
+
+    if message.chat.type != "private":
+        await message.answer(
+            "⚠️ Completa il collegamento in chat privata con il bot per motivi di sicurezza."
+        )
+        return
+
+    username = (message.text or "").strip()
+    if not username:
+        await message.answer("❌ Inserisci uno username valido.")
+        return
+
+    player_info = await fetch_player_by_username(username)
+    if not player_info or not player_info.get("id"):
+        await message.answer(
+            "❌ Non ho trovato alcun giocatore con questo username. "
+            "Controlla l'ortografia e riprova."
+        )
+        return
+
+    canonical_username = player_info.get("username") or username
+    clan_id = player_info.get("clanId")
+    if clan_id != CLAN_ID:
+        await message.answer(
+            "⚠️ Il profilo indicato non risulta appartenere al clan. "
+            "Contatta un amministratore se ritieni si tratti di un errore."
+        )
+        return
+
+    verification_code = generate_verification_code()
+    await state.update_data(
+        pending_username=canonical_username,
+        player_id=player_info.get("id"),
+        verification_code=verification_code,
+    )
+
+    instructions = (
+        f"Per verificare la proprietà dell'account <b>{canonical_username}</b> inserisci il codice "
+        f"<code>{verification_code}</code> nel tuo messaggio personale su Wolvesville.\n"
+        "Dopo averlo aggiornato premi il pulsante qui sotto. Potrai rimuovere il codice dal profilo una volta completata la verifica."
+    )
+
+    await message.answer(instructions, reply_markup=build_verification_keyboard())
+    await state.set_state(LinkStates.WAITING_VERIFICATION)
+
+
+@dp.message(LinkStates.WAITING_VERIFICATION)
+async def remind_verification_step(message: types.Message, state: FSMContext):
+    """Ricorda all'utente di confermare il codice di verifica."""
+
+    data = await state.get_data()
+    code = data.get("verification_code", "")
+    reminder = (
+        "Quando hai aggiornato il tuo messaggio personale con il codice "
+        f"<code>{code}</code> premi il pulsante ✅ Ho aggiornato il profilo."
+    )
+    await message.answer(reminder, reply_markup=build_verification_keyboard())
+
+
+@dp.callback_query(LinkStates.WAITING_VERIFICATION, F.data == "link_cancel")
+async def cancel_linking(callback: types.CallbackQuery, state: FSMContext):
+    """Annulla il processo di collegamento."""
+
+    await state.clear()
+    try:
+        await callback.message.edit_reply_markup()
+    except Exception:
+        pass
+    await callback.answer("Collegamento annullato")
+    await callback.message.answer(
+        "❎ Collegamento annullato. Potrai ripetere il comando /collega quando vorrai."
+    )
+
+
+@dp.callback_query(LinkStates.WAITING_VERIFICATION, F.data == "link_verify")
+async def finalize_profile_link(callback: types.CallbackQuery, state: FSMContext):
+    """Verifica il codice inserito nel profilo Wolvesville e completa il collegamento."""
+
+    await ensure_telegram_profile_synced(callback.from_user)
+
+    data = await state.get_data()
+    username = data.get("pending_username")
+    verification_code = data.get("verification_code")
+    player_id = data.get("player_id")
+
+    if not username or not verification_code or not player_id:
+        await callback.answer(
+            "Sessione scaduta, ripeti /collega per ricominciare.", show_alert=True
+        )
+        await state.clear()
+        return
+
+    player_info = await fetch_player_by_id(player_id)
+    if not player_info:
+        await callback.answer(
+            "Non riesco a recuperare il profilo, riprova tra qualche secondo.",
+            show_alert=True,
+        )
+        return
+
+    personal_message = player_info.get("personalMessage") or ""
+    if verification_code not in personal_message:
+        await callback.answer(
+            "Non ho trovato il codice nel tuo messaggio personale. "
+            "Assicurati di averlo inserito e riprova.",
+            show_alert=True,
+        )
+        return
+
+    clan_id = player_info.get("clanId")
+    if clan_id != CLAN_ID:
+        await callback.answer(
+            "Il profilo non risulta nel clan, contatta un amministratore.",
+            show_alert=True,
+        )
+        return
+
+    result = await db_manager.link_player_profile(
+        callback.from_user.id,
+        game_username=player_info.get("username", username),
+        telegram_username=callback.from_user.username,
+        full_name=" ".join(
+            part
+            for part in [callback.from_user.first_name, callback.from_user.last_name]
+            if part
+        ).strip()
+        or None,
+        wolvesville_id=player_info.get("id"),
+        verified=True,
+        verification_code=verification_code,
+        verification_method="personal_message",
+    )
+
+    if result.get("conflict"):
+        await callback.answer(
+            "Questo profilo è già collegato a un altro utente. Contatta un admin.",
+            show_alert=True,
+        )
+        return
+
+    profile = result.get("profile") or {}
+    telegram_username_display = format_telegram_username(
+        profile.get("telegram_username")
+    )
+
+    summary_lines = [
+        "✅ <b>Collegamento completato!</b>",
+        f"🎮 Username di gioco: <b>{profile.get('game_username', username)}</b>",
+        f"💬 Telegram: {telegram_username_display}",
+        "Ricorda di rimuovere il codice dal tuo messaggio personale.",
+    ]
+
+    if result.get("game_username_changed") and result.get("previous_game_username"):
+        summary_lines.append(
+            f"🔁 Nome precedente registrato: {result['previous_game_username']}"
+        )
+
+    await state.clear()
+    try:
+        await callback.message.edit_text("\n".join(summary_lines))
+    except Exception:
+        await callback.message.answer("\n".join(summary_lines))
+
+    await callback.answer("Profilo verificato!", show_alert=False)
+
+    if notification_service:
+        admin_lines = [
+            "🔗 <b>Profilo Wolvesville collegato</b>",
+            f"🎮 <b>Username:</b> {profile.get('game_username', username)}",
+            f"🆔 <b>Wolvesville ID:</b> {profile.get('wolvesville_id', '—')}",
+            f"💬 <b>Telegram:</b> {telegram_username_display}",
+            f"🆔 <b>Telegram ID:</b> <code>{profile.get('telegram_id')}</code>",
+        ]
+        if result.get("created"):
+            admin_lines.append("✨ Nuovo collegamento creato.")
+        if result.get("game_username_changed") and result.get("previous_game_username"):
+            admin_lines.append(
+                "🔁 Username di gioco aggiornato: "
+                f"{result['previous_game_username']} → {profile.get('game_username')}"
+            )
+        if result.get("telegram_username_changed"):
+            admin_lines.append(
+                "📛 Username Telegram aggiornato: "
+                f"{format_telegram_username(result.get('previous_telegram_username'))} → {telegram_username_display}"
+            )
+        migrate_result = result.get("migrate_result") or {}
+        if migrate_result.get("status") and migrate_result.get("status") != "unchanged":
+            admin_lines.append(
+                f"🗃️ Migrazione dati utenti: {migrate_result.get('status')}"
+            )
+        verification_payload = result.get("verification")
+        if verification_payload:
+            admin_lines.append(
+                "🔐 Verifica completata via "
+                f"{verification_payload.get('method', 'sconosciuta')}"
+            )
+        try:
+            await notification_service.send_admin_notification(
+                "\n".join(admin_lines),
+                notification_type=NotificationType.SUCCESS,
+            )
+        except Exception as exc:
+            logger.warning("Impossibile inviare la notifica di collegamento: %s", exc)
+
 
 # =============================================================================
 # COMANDO /START
@@ -1589,16 +2286,15 @@ async def enable_votes_callback(callback: types.CallbackQuery, state: FSMContext
 """BILANCI """
 @dp.message(Command("balances"))
 async def show_balances(message: types.Message):
-    cursor = users_col.find({})
+    users = await db_manager.list_users()
     logger.info("Sto per costruire la tabella bilanci. Ecco i documenti dal DB:")
-    # Logga i doc
-    async for doc in users_col.find({}):
+    for doc in users:
         logger.info(f"Doc utente: {doc}")
     lines = []
     lines.append("Utente           Oro     Gem")
     lines.append("-----------------------------")
 
-    async for doc in cursor:
+    for doc in users:
         username = doc.get("username", "Sconosciuto")
         donazioni = doc.get("donazioni", {})
         oro = donazioni.get("Oro", 0)
@@ -1845,8 +2541,8 @@ async def modify_start(callback: types.CallbackQuery, state: FSMContext):
 
     try:
         players = []
-        cursor = users_col.find({})
-        async for doc in cursor:
+        users = await db_manager.list_users()
+        for doc in users:
             username = doc.get("username", "Sconosciuto")
             if username != "Sconosciuto":  # Filtra username validi
                 players.append(username)
@@ -1961,14 +2657,8 @@ async def modify_enter_amount(message: types.Message, state: FSMContext):
             await state.clear()
             return
 
-        field_name = f"donazioni.{db_key}"
-
         # Aggiorna il DB
-        await users_col.update_one(
-            {"username": username},
-            {"$set": {field_name: new_amount}},
-            upsert=True
-        )
+        await db_manager.set_user_currency(username, db_key, new_amount)
 
         msg = await message.answer(
             f"✅ {currency} di <b>{username}</b> aggiornato a: <b>{new_amount:,}</b>",

--- a/reward_service.py
+++ b/reward_service.py
@@ -1,9 +1,9 @@
-from datetime import datetime, timedelta
-from typing import Dict, List
-import asyncio
+from typing import Dict, List, Optional
+
+from services.db_manager import MongoManager
 
 class RewardService:
-    def __init__(self, db_manager):
+    def __init__(self, db_manager: MongoManager):
         self.db = db_manager
         
         # Configurazione punti
@@ -23,33 +23,66 @@ class RewardService:
             "CLAN_LEGEND": {"points": 100, "name": "Leggenda del Clan", "icon": "👑"}
         }
         
-    async def award_points(self, username: str, point_type: str, amount: int = None):
+    async def award_points(
+        self, username: str, point_type: str, amount: Optional[int] = None
+    ) -> int:
         """Assegna punti a un utente"""
+        safe_amount = max(amount or 0, 0)
+
+        canonical_username = (username or "").strip()
+        if not canonical_username:
+            return 0
+
+        try:
+            resolution = await self.db.resolve_profile_by_game_alias(canonical_username)
+        except Exception:
+            resolution = None
+
+        if resolution and resolution.get("resolved_username"):
+            canonical_username = resolution.get("resolved_username")
+
         if point_type == "DONATION_ORO":
-            points = max(1, amount // 1000) * self.POINTS_CONFIG["DONATION_ORO"]
+            base_units = safe_amount // 1000
+            if safe_amount > 0:
+                base_units = max(1, base_units)
+            points = base_units * self.POINTS_CONFIG["DONATION_ORO"]
         elif point_type == "DONATION_GEM":
-            points = max(1, amount // 1000) * self.POINTS_CONFIG["DONATION_GEM"]
+            base_units = safe_amount // 1000
+            if safe_amount > 0:
+                base_units = max(1, base_units)
+            points = base_units * self.POINTS_CONFIG["DONATION_GEM"]
         else:
             points = self.POINTS_CONFIG.get(point_type, 0)
-            
+
+        if points <= 0:
+            return 0
+
         # Aggiorna database
-        await self.db.users_col.update_one(
-            {"username": username},
-            {"$inc": {"reward_points": points}},
-            upsert=True
-        )
-        
+        await self.db.increment_reward_points(canonical_username, points)
+
         # Controlla achievement
-        await self.check_achievements(username)
-        
+        await self.check_achievements(canonical_username)
+
         return points
         
     async def check_achievements(self, username: str):
         """Controlla se l'utente ha sbloccato achievement"""
-        user_data = await self.db.users_col.find_one({"username": username})
+        target_username = (username or "").strip()
+        if not target_username:
+            return []
+
+        user_data = await self.db.fetch_user(target_username)
         if not user_data:
-            return
-            
+            try:
+                resolution = await self.db.resolve_profile_by_game_alias(target_username)
+            except Exception:
+                resolution = None
+            if resolution and resolution.get("resolved_username"):
+                target_username = resolution.get("resolved_username")
+                user_data = await self.db.fetch_user(target_username)
+        if not user_data:
+            return []
+
         donazioni = user_data.get("donazioni", {})
         total_oro = donazioni.get("Oro", 0)
         total_gem = donazioni.get("Gem", 0)
@@ -67,11 +100,8 @@ class RewardService:
             
         # Aggiorna database con nuovi achievement
         if new_achievements:
-            await self.db.users_col.update_one(
-                {"username": username},
-                {"$addToSet": {"achievements": {"$each": new_achievements}}}
-            )
-            
+            await self.db.add_achievements(target_username, new_achievements)
+
         return new_achievements
         
     async def get_leaderboard(self, limit: int = 10) -> List[Dict]:
@@ -82,5 +112,5 @@ class RewardService:
             {"$limit": limit}
         ]
         
-        leaderboard = await self.db.users_col.aggregate(pipeline).to_list(length=None)
+        leaderboard = await self.db.aggregate_users(pipeline)
         return leaderboard

--- a/services/db_manager.py
+++ b/services/db_manager.py
@@ -1,0 +1,706 @@
+"""Strato di accesso ai dati centralizzato per il bot Wolvesville."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import re
+from typing import Any, Dict, List, Optional, Sequence
+from uuid import uuid4
+
+from motor.motor_asyncio import (
+    AsyncIOMotorClient,
+    AsyncIOMotorCollection,
+    AsyncIOMotorDatabase,
+)
+
+
+class MongoManager:
+    """Incapsula l'accesso alle principali collezioni MongoDB."""
+
+    def __init__(self, client: AsyncIOMotorClient, database_name: str) -> None:
+        self._client = client
+        self._database: AsyncIOMotorDatabase = client[database_name]
+
+        self.users_col: AsyncIOMotorCollection = self._database["users"]
+        self.processed_ledger_col: AsyncIOMotorCollection = self._database["processed_ledger"]
+        self.processed_active_missions_col: AsyncIOMotorCollection = self._database[
+            "processed_active_missions"
+        ]
+        self.donation_history_col: AsyncIOMotorCollection = self._database["donation_history"]
+        self.missions_history_col: AsyncIOMotorCollection = self._database["missions_history"]
+        self.player_profiles_col: AsyncIOMotorCollection = self._database["player_profiles"]
+
+    @property
+    def database(self) -> AsyncIOMotorDatabase:
+        """Restituisce il database MongoDB sottostante."""
+
+        return self._database
+
+    @staticmethod
+    def _normalize_currency(currency: str) -> str:
+        mapping = {
+            "gold": "Oro",
+            "oro": "Oro",
+            "gem": "Gem",
+            "gems": "Gem",
+            "gemme": "Gem",
+        }
+        return mapping.get(currency.lower(), currency.capitalize())
+
+    def normalize_currency(self, currency: str) -> str:
+        """Espone la normalizzazione delle valute."""
+
+        return self._normalize_currency(currency)
+
+    async def ensure_user(self, username: str) -> bool:
+        """Crea l'utente se non esiste, restituendo True se inserito."""
+
+        if not username:
+            return False
+
+        result = await self.users_col.update_one(
+            {"username": username},
+            {"$setOnInsert": {"donazioni": {"Oro": 0, "Gem": 0}, "username": username}},
+            upsert=True,
+        )
+        return bool(getattr(result, "upserted_id", None))
+
+    async def update_user_balance(self, username: str, currency: str, amount: int) -> str:
+        """Incrementa il bilancio di un utente per la valuta indicata."""
+
+        normalized = self._normalize_currency(currency)
+        field = f"donazioni.{normalized}"
+        await self.users_col.update_one(
+            {"username": username},
+            {"$inc": {field: amount}, "$setOnInsert": {"username": username}},
+            upsert=True,
+        )
+        return normalized
+
+    async def set_user_currency(self, username: str, currency: str, value: int) -> str:
+        """Imposta il valore assoluto di una valuta per l'utente."""
+
+        normalized = self._normalize_currency(currency)
+        field = f"donazioni.{normalized}"
+        await self.users_col.update_one(
+            {"username": username},
+            {"$set": {field: value}, "$setOnInsert": {"username": username}},
+            upsert=True,
+        )
+        return normalized
+
+    async def list_users(self) -> List[Dict[str, Any]]:
+        """Restituisce tutti gli utenti presenti nella collezione."""
+
+        return await self.users_col.find({}).to_list(length=None)
+
+    async def remove_duplicate_users(self) -> List[Dict[str, Any]]:
+        """Elimina eventuali duplicati e restituisce un riepilogo delle rimozioni."""
+
+        pipeline = [
+            {"$group": {"_id": "$username", "count": {"$sum": 1}, "docs": {"$push": "$_id"}}},
+            {"$match": {"count": {"$gt": 1}}},
+        ]
+        duplicates = await self.users_col.aggregate(pipeline).to_list(length=None)
+
+        removed_info: List[Dict[str, Any]] = []
+        for duplicate in duplicates:
+            username = duplicate.get("_id")
+            doc_ids = duplicate.get("docs", [])
+            docs_to_delete = doc_ids[1:]
+            if not docs_to_delete:
+                continue
+
+            delete_result = await self.users_col.delete_many({"_id": {"$in": docs_to_delete}})
+            removed_info.append(
+                {
+                    "username": username,
+                    "removed": delete_result.deleted_count,
+                    "removed_ids": docs_to_delete,
+                }
+            )
+
+        return removed_info
+
+    @staticmethod
+    def _merge_donation_maps(*donation_maps: Optional[Dict[str, Any]]) -> Dict[str, int]:
+        """Unisce più mappe di donazioni sommando i valori numerici."""
+
+        merged: Dict[str, int] = {}
+        for donations in donation_maps:
+            if not donations:
+                continue
+            for currency, value in donations.items():
+                try:
+                    merged[currency] = merged.get(currency, 0) + int(value or 0)
+                except (TypeError, ValueError):
+                    continue
+        return merged
+
+    async def migrate_user_record(self, old_username: str, new_username: str) -> Dict[str, Any]:
+        """Rinomina o unisce i documenti utente quando cambia l'username di gioco."""
+
+        if not old_username or not new_username or old_username == new_username:
+            return {"status": "unchanged"}
+
+        old_doc = await self.users_col.find_one({"username": old_username})
+        if not old_doc:
+            return {"status": "missing_old"}
+
+        new_doc = await self.users_col.find_one({"username": new_username})
+        if not new_doc:
+            await self.users_col.update_one(
+                {"_id": old_doc["_id"]},
+                {"$set": {"username": new_username}},
+            )
+            return {"status": "renamed", "updated_id": str(old_doc["_id"])}
+
+        merged_donations = self._merge_donation_maps(
+            old_doc.get("donazioni"), new_doc.get("donazioni")
+        )
+        merged_reward_points = 0
+        for doc in (old_doc, new_doc):
+            try:
+                merged_reward_points += int(doc.get("reward_points", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+
+        achievements = set()
+        for doc in (old_doc, new_doc):
+            for achievement in doc.get("achievements", []) or []:
+                if achievement:
+                    achievements.add(str(achievement))
+
+        update_payload: Dict[str, Any] = {"donazioni": merged_donations}
+        if achievements:
+            update_payload["achievements"] = sorted(achievements)
+        update_payload["reward_points"] = merged_reward_points
+
+        await self.users_col.update_one(
+            {"_id": new_doc["_id"]},
+            {"$set": update_payload},
+        )
+        await self.users_col.delete_one({"_id": old_doc["_id"]})
+
+        return {
+            "status": "merged",
+            "deleted_old_id": str(old_doc["_id"]),
+            "kept_id": str(new_doc["_id"]),
+        }
+
+    async def remove_user_by_username(self, username: str) -> int:
+        """Rimuove un utente in base all'username e restituisce il conteggio eliminato."""
+
+        if not username:
+            return 0
+        result = await self.users_col.delete_one({"username": username})
+        return result.deleted_count
+
+    async def has_processed_ledger(self, record_id: str) -> bool:
+        """Verifica se un record del ledger è già stato processato."""
+
+        if not record_id:
+            return False
+        doc = await self.processed_ledger_col.find_one({"_id": record_id})
+        return doc is not None
+
+    async def mark_ledger_processed(
+        self,
+        record_id: str,
+        *,
+        raw_record: Optional[Dict[str, Any]] = None,
+        processed_at: Optional[datetime] = None,
+    ) -> None:
+        """Memorizza l'elaborazione di un record del ledger."""
+
+        if not record_id:
+            return
+        processed_time = processed_at or datetime.now(timezone.utc)
+        payload: Dict[str, Any] = {"_id": record_id, "processed_at": processed_time}
+        if raw_record is not None:
+            payload["raw"] = raw_record
+        await self.processed_ledger_col.replace_one({"_id": record_id}, payload, upsert=True)
+
+    async def log_donation(
+        self,
+        record_id: str,
+        username: str,
+        gold_amount: int,
+        gems_amount: int,
+        *,
+        raw_record: Optional[Dict[str, Any]] = None,
+        processed_at: Optional[datetime] = None,
+        telegram_id: Optional[int] = None,
+        telegram_username: Optional[str] = None,
+        profile_snapshot: Optional[Dict[str, Any]] = None,
+        original_username: Optional[str] = None,
+        match_source: Optional[str] = None,
+    ) -> None:
+        """Archivia il dettaglio di una donazione elaborata."""
+
+        if not record_id or not username:
+            return
+        processed_time = processed_at or datetime.now(timezone.utc)
+        entry: Dict[str, Any] = {
+            "_id": record_id,
+            "username": username,
+            "gold": int(gold_amount or 0),
+            "gems": int(gems_amount or 0),
+            "processed_at": processed_time,
+        }
+        if original_username:
+            entry["original_username"] = original_username
+        if telegram_id is not None:
+            try:
+                entry["telegram_id"] = int(telegram_id)
+            except (TypeError, ValueError):
+                pass
+        if telegram_username:
+            entry["telegram_username"] = telegram_username
+        if match_source:
+            entry["identity_match"] = match_source
+        if profile_snapshot:
+            entry["profile_snapshot"] = profile_snapshot
+        if raw_record is not None:
+            entry["raw"] = raw_record
+        await self.donation_history_col.replace_one({"_id": record_id}, entry, upsert=True)
+
+    async def has_processed_active_mission(self, mission_id: str) -> bool:
+        """Controlla se una missione attiva è già stata processata."""
+
+        if not mission_id:
+            return False
+        doc = await self.processed_active_missions_col.find_one({"_id": mission_id})
+        return doc is not None
+
+    async def mark_active_mission_processed(
+        self,
+        mission_id: str,
+        tier_start_time: Optional[str] = None,
+        *,
+        processed_at: Optional[datetime] = None,
+    ) -> None:
+        """Segna una missione attiva come elaborata."""
+
+        if not mission_id:
+            return
+        processed_time = processed_at or datetime.now(timezone.utc)
+        payload: Dict[str, Any] = {
+            "_id": mission_id,
+            "processed_at": processed_time,
+        }
+        if tier_start_time is not None:
+            payload["tierStartTime"] = tier_start_time
+        await self.processed_active_missions_col.replace_one({"_id": mission_id}, payload, upsert=True)
+
+    async def log_mission_participation(
+        self,
+        mission_id: Optional[str],
+        mission_type: str,
+        participants: Sequence[Any],
+        *,
+        cost_per_participant: int,
+        outcome: str = "processed",
+        source: str = "manual",
+        occurred_at: Optional[datetime] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Registra la partecipazione a una missione in una collezione dedicata."""
+
+        processed_time = occurred_at or datetime.now(timezone.utc)
+        event_id = f"{mission_id or 'mission'}-{uuid4()}"
+        participant_entries: List[Dict[str, Any]] = []
+        for participant in participants:
+            entry: Dict[str, Any]
+            if isinstance(participant, dict):
+                username_value = (participant.get("username") or "").strip()
+                if not username_value:
+                    continue
+                entry = {"username": username_value, "cost": cost_per_participant}
+                original_username = participant.get("original_username")
+                if original_username:
+                    entry["original_username"] = original_username
+                telegram_id = participant.get("telegram_id")
+                if telegram_id is not None:
+                    try:
+                        entry["telegram_id"] = int(telegram_id)
+                    except (TypeError, ValueError):
+                        pass
+                telegram_username = participant.get("telegram_username")
+                if telegram_username:
+                    entry["telegram_username"] = telegram_username
+                match_source = participant.get("match")
+                if match_source:
+                    entry["identity_match"] = match_source
+                profile_snapshot = participant.get("profile_snapshot")
+                if profile_snapshot:
+                    entry["profile_snapshot"] = profile_snapshot
+            else:
+                username_value = str(participant).strip()
+                if not username_value:
+                    continue
+                entry = {
+                    "username": username_value,
+                    "original_username": username_value,
+                    "cost": cost_per_participant,
+                }
+            participant_entries.append(entry)
+
+        if not participant_entries:
+            return None
+
+        document: Dict[str, Any] = {
+            "_id": event_id,
+            "mission_id": mission_id,
+            "mission_type": mission_type,
+            "participants": participant_entries,
+            "participant_count": len(participant_entries),
+            "outcome": outcome,
+            "source": source,
+            "cost_per_participant": cost_per_participant,
+            "total_cost": cost_per_participant * len(participant_entries),
+            "processed_at": processed_time,
+        }
+        if metadata:
+            document["metadata"] = metadata
+
+        result = await self.missions_history_col.insert_one(document)
+        return str(result.inserted_id)
+
+    async def fetch_user(self, username: str) -> Optional[Dict[str, Any]]:
+        """Recupera i dati di un utente dal database."""
+
+        if not username:
+            return None
+        return await self.users_col.find_one({"username": username})
+
+    async def increment_reward_points(self, username: str, points: int) -> None:
+        """Incrementa i punti ricompensa di un utente."""
+
+        if not username or points == 0:
+            return
+        await self.users_col.update_one(
+            {"username": username},
+            {"$inc": {"reward_points": points}, "$setOnInsert": {"username": username}},
+            upsert=True,
+        )
+
+    async def add_achievements(self, username: str, achievements: Sequence[str]) -> None:
+        """Aggiunge nuovi achievement all'utente, evitando duplicati."""
+
+        achievements_list = list(achievements)
+        if not username or not achievements_list:
+            return
+        await self.users_col.update_one(
+            {"username": username},
+            {"$addToSet": {"achievements": {"$each": achievements_list}}},
+        )
+
+    async def aggregate_users(self, pipeline: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Esegue un'aggregazione sugli utenti."""
+
+        return await self.users_col.aggregate(list(pipeline)).to_list(length=None)
+
+    async def get_profile_by_telegram_id(self, telegram_id: int) -> Optional[Dict[str, Any]]:
+        """Recupera il profilo collegato a un determinato Telegram ID."""
+
+        if not telegram_id:
+            return None
+        return await self.player_profiles_col.find_one({"telegram_id": telegram_id})
+
+    async def get_profile_by_game_username(self, game_username: str) -> Optional[Dict[str, Any]]:
+        """Recupera il profilo a partire dallo username di gioco."""
+
+        if not game_username:
+            return None
+        normalized = game_username.strip().lower()
+        return await self.player_profiles_col.find_one({"game_username_lower": normalized})
+
+    async def resolve_profile_by_game_alias(
+        self, game_username: str
+    ) -> Optional[Dict[str, Any]]:
+        """Risolvi un profilo partendo da uno username o da un alias storico."""
+
+        if not game_username:
+            return None
+
+        normalized_username = game_username.strip()
+        if not normalized_username:
+            return None
+
+        normalized_lower = normalized_username.lower()
+
+        profile = await self.player_profiles_col.find_one(
+            {"game_username_lower": normalized_lower}
+        )
+        if profile:
+            return {
+                "profile": profile,
+                "resolved_username": profile.get("game_username")
+                or normalized_username,
+                "match": "current",
+            }
+
+        profile = await self.player_profiles_col.find_one(
+            {"game_username_history": {"$elemMatch": {"username_lower": normalized_lower}}}
+        )
+        if profile:
+            return {
+                "profile": profile,
+                "resolved_username": profile.get("game_username")
+                or normalized_username,
+                "match": "history",
+            }
+
+        regex = re.compile(rf"^{re.escape(normalized_username)}$", re.IGNORECASE)
+        profile = await self.player_profiles_col.find_one(
+            {"game_username_history": {"$elemMatch": {"username": regex}}}
+        )
+        if profile:
+            return {
+                "profile": profile,
+                "resolved_username": profile.get("game_username")
+                or normalized_username,
+                "match": "history",
+            }
+
+        return None
+
+    async def sync_telegram_metadata(
+        self,
+        telegram_id: int,
+        *,
+        telegram_username: Optional[str],
+        full_name: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Aggiorna le informazioni Telegram e traccia lo storico delle modifiche."""
+
+        if not telegram_id:
+            return None
+
+        now = datetime.now(timezone.utc)
+        normalized_username = telegram_username.lower() if telegram_username else None
+        clean_full_name = full_name.strip() if full_name else None
+
+        profile = await self.player_profiles_col.find_one({"telegram_id": telegram_id})
+        if profile is None:
+            document: Dict[str, Any] = {
+                "_id": str(telegram_id),
+                "telegram_id": telegram_id,
+                "telegram_username": telegram_username,
+                "telegram_username_lower": normalized_username,
+                "telegram_username_history": [],
+                "game_username": None,
+                "game_username_lower": None,
+                "game_username_history": [],
+                "created_at": now,
+                "updated_at": now,
+            }
+            if clean_full_name:
+                document["full_name"] = clean_full_name
+            if telegram_username:
+                document["telegram_username_history"].append({
+                    "username": telegram_username,
+                    "username_lower": normalized_username,
+                    "set_at": now,
+                })
+            await self.player_profiles_col.insert_one(document)
+            return {"created": True, "profile": document}
+
+        update_doc: Dict[str, Any] = {"updated_at": now}
+        push_ops: Dict[str, Any] = {}
+        changes: Dict[str, Any] = {}
+
+        if telegram_username is not None and telegram_username != profile.get("telegram_username"):
+            changes["telegram_username_changed"] = True
+            changes["previous_telegram_username"] = profile.get("telegram_username")
+            update_doc["telegram_username"] = telegram_username
+            update_doc["telegram_username_lower"] = normalized_username
+            push_ops["telegram_username_history"] = {
+                "username": telegram_username,
+                "username_lower": normalized_username,
+                "set_at": now,
+            }
+
+        if clean_full_name and clean_full_name != profile.get("full_name"):
+            update_doc["full_name"] = clean_full_name
+
+        if not changes and len(update_doc) == 1:  # solo updated_at
+            return None
+
+        update_operations: Dict[str, Any] = {"$set": update_doc}
+        if push_ops:
+            update_operations["$push"] = {
+                field: {"$each": [value]} for field, value in push_ops.items()
+            }
+
+        await self.player_profiles_col.update_one(
+            {"_id": profile["_id"]},
+            update_operations,
+        )
+
+        if changes:
+            profile = await self.player_profiles_col.find_one({"telegram_id": telegram_id})
+            changes["profile"] = profile
+            return changes
+        return None
+
+    async def link_player_profile(
+        self,
+        telegram_id: int,
+        *,
+        game_username: str,
+        telegram_username: Optional[str],
+        full_name: Optional[str] = None,
+        wolvesville_id: Optional[str] = None,
+        verified: bool = False,
+        verification_code: Optional[str] = None,
+        verification_method: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Collega un profilo Telegram a uno username Wolvesville, tracciando gli storici."""
+
+        normalized_username = game_username.strip()
+        if not normalized_username:
+            raise ValueError("game_username richiesto")
+
+        now = datetime.now(timezone.utc)
+        normalized_lower = normalized_username.lower()
+        clean_full_name = full_name.strip() if full_name else None
+        normalized_telegram_lower = telegram_username.lower() if telegram_username else None
+
+        existing_profile = await self.player_profiles_col.find_one({"telegram_id": telegram_id})
+
+        existing_by_username = await self.player_profiles_col.find_one(
+            {"game_username_lower": normalized_lower}
+        )
+        if (
+            existing_by_username
+            and existing_by_username.get("telegram_id") != telegram_id
+        ):
+            return {
+                "conflict": True,
+                "reason": "game_username",
+                "conflicting_profile": existing_by_username,
+            }
+
+        existing_by_wolvesville_id: Optional[Dict[str, Any]] = None
+        if wolvesville_id:
+            existing_by_wolvesville_id = await self.player_profiles_col.find_one(
+                {"wolvesville_id": wolvesville_id}
+            )
+            if (
+                existing_by_wolvesville_id
+                and existing_by_wolvesville_id.get("telegram_id") != telegram_id
+            ):
+                return {
+                    "conflict": True,
+                    "reason": "wolvesville_id",
+                    "conflicting_profile": existing_by_wolvesville_id,
+                }
+
+        update_doc: Dict[str, Any] = {
+            "telegram_id": telegram_id,
+            "game_username": normalized_username,
+            "game_username_lower": normalized_lower,
+            "updated_at": now,
+        }
+        if telegram_username is not None:
+            update_doc["telegram_username"] = telegram_username
+            update_doc["telegram_username_lower"] = normalized_telegram_lower
+        if clean_full_name:
+            update_doc["full_name"] = clean_full_name
+        if wolvesville_id:
+            update_doc["wolvesville_id"] = wolvesville_id
+
+        set_on_insert: Dict[str, Any] = {
+            "_id": str(telegram_id),
+            "telegram_id": telegram_id,
+            "created_at": now,
+            "telegram_username_history": [],
+            "game_username_history": [],
+            "verification_history": [],
+        }
+
+        push_ops: Dict[str, Any] = {}
+        changes: Dict[str, Any] = {
+            "created": False,
+            "game_username_changed": False,
+            "previous_game_username": None,
+            "telegram_username_changed": False,
+            "previous_telegram_username": None,
+            "migrate_result": None,
+        }
+
+        if existing_profile is None:
+            changes["created"] = True
+            if normalized_username:
+                push_ops["game_username_history"] = {
+                    "username": normalized_username,
+                    "username_lower": normalized_lower,
+                    "set_at": now,
+                }
+            if telegram_username:
+                push_ops["telegram_username_history"] = {
+                    "username": telegram_username,
+                    "username_lower": normalized_telegram_lower,
+                    "set_at": now,
+                }
+        else:
+            if normalized_username != existing_profile.get("game_username"):
+                changes["game_username_changed"] = True
+                changes["previous_game_username"] = existing_profile.get("game_username")
+                push_ops["game_username_history"] = {
+                    "username": normalized_username,
+                    "username_lower": normalized_lower,
+                    "set_at": now,
+                }
+            if (
+                telegram_username is not None
+                and telegram_username != existing_profile.get("telegram_username")
+            ):
+                changes["telegram_username_changed"] = True
+                changes["previous_telegram_username"] = existing_profile.get(
+                    "telegram_username"
+                )
+                push_ops["telegram_username_history"] = {
+                    "username": telegram_username,
+                    "username_lower": normalized_telegram_lower,
+                    "set_at": now,
+                }
+
+        verification_payload: Optional[Dict[str, Any]] = None
+        if verified:
+            verification_payload = {
+                "status": "verified",
+                "verified_at": now,
+                "method": verification_method or "manual",
+            }
+            if verification_code:
+                verification_payload["code"] = verification_code
+            update_doc["verification"] = verification_payload
+            push_ops["verification_history"] = verification_payload
+
+        update_operations: Dict[str, Any] = {"$set": update_doc, "$setOnInsert": set_on_insert}
+        if push_ops:
+            update_operations["$push"] = {
+                field: {"$each": [value]} for field, value in push_ops.items()
+            }
+
+        await self.player_profiles_col.update_one(
+            {"telegram_id": telegram_id},
+            update_operations,
+            upsert=True,
+        )
+
+        profile = await self.player_profiles_col.find_one({"telegram_id": telegram_id})
+
+        if changes["game_username_changed"] and changes["previous_game_username"]:
+            changes["migrate_result"] = await self.migrate_user_record(
+                changes["previous_game_username"], normalized_username
+            )
+
+        changes["profile"] = profile
+        if verification_payload is not None:
+            changes["verification"] = verification_payload
+
+        return changes


### PR DESCRIPTION
## Summary
- resolve Wolvesville usernames through linked Telegram profiles before updating ledger balances or mission costs, logging alias migrations for admins
- extend the Mongo data layer with alias-aware lookups, normalized history entries, and richer donation/mission audit records including Telegram metadata
- normalize reward point attribution by reusing the alias resolver so streaks and achievements follow the current game identity

## Testing
- python -m compileall bot.py services/db_manager.py reward_service.py

------
https://chatgpt.com/codex/tasks/task_e_68c979a722808323a6abcde721bac6a6