### PR TITLE
Modularizza missioni e scheduler

### DIFF
--- a/bot_app/__init__.py
+++ b/bot_app/__init__.py
@@ -1,0 +1,8 @@
+"""Utility per inizializzare il bot suddivise per moduli."""
+
+from .bootstrap import BotAppContext, create_app_context
+
+__all__ = [
+    "BotAppContext",
+    "create_app_context",
+]

--- a/bot_app/bootstrap.py
+++ b/bot_app/bootstrap.py
@@ -1,0 +1,110 @@
+"""Funzioni di bootstrap e configurazione dell'applicazione del bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+
+import motor.motor_asyncio
+from aiogram import Bot, Dispatcher
+from aiogram.client.bot import DefaultBotProperties
+from aiogram.client.session.aiohttp import AiohttpSession
+from aiogram.fsm.storage.memory import MemoryStorage
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from services.db_manager import MongoManager
+from services.notification_service import EnhancedNotificationService
+
+
+@dataclass(slots=True)
+class BotAppContext:
+    """Contenitore per le dipendenze condivise del bot."""
+
+    bot: Bot
+    dispatcher: Dispatcher
+    notification_service: EnhancedNotificationService
+    db_manager: MongoManager
+    scheduler: AsyncIOScheduler
+    mongo_client: motor.motor_asyncio.AsyncIOMotorClient
+
+
+def _create_bot(token: str) -> Bot:
+    """Crea l'istanza di :class:`aiogram.Bot` con la configurazione di default."""
+
+    session = AiohttpSession()
+    default_properties = DefaultBotProperties(parse_mode="HTML")
+    return Bot(token=token, session=session, default=default_properties)
+
+
+def _create_dispatcher() -> Dispatcher:
+    """Crea un dispatcher con storage in memoria."""
+
+    return Dispatcher(storage=MemoryStorage())
+
+
+def _create_mongo_manager(
+    uri: str, database_name: str
+) -> Tuple[motor.motor_asyncio.AsyncIOMotorClient, MongoManager]:
+    """Inizializza il client MongoDB e il relativo manager applicativo."""
+
+    client = motor.motor_asyncio.AsyncIOMotorClient(
+        uri,
+        tlsAllowInvalidCertificates=True,
+    )
+    manager = MongoManager(client, database_name)
+    return client, manager
+
+
+def _create_notification_service(
+    bot: Bot,
+    admin_ids: Sequence[int],
+    admin_channel_id: Optional[int],
+    owner_id: Optional[int],
+) -> EnhancedNotificationService:
+    """Configura il servizio di notifiche amministrative."""
+
+    return EnhancedNotificationService(
+        bot=bot,
+        admin_ids=list(admin_ids),
+        admin_channel_id=admin_channel_id,
+        owner_id=owner_id,
+    )
+
+
+def _create_scheduler(timezone: str) -> AsyncIOScheduler:
+    """Restituisce uno scheduler asincrono configurato con il fuso richiesto."""
+
+    return AsyncIOScheduler(timezone=timezone)
+
+
+def create_app_context(
+    *,
+    token: str,
+    mongo_uri: str,
+    database_name: str,
+    admin_ids: Sequence[int],
+    admin_channel_id: Optional[int],
+    owner_id: Optional[int],
+    scheduler_timezone: str = "Europe/Rome",
+) -> BotAppContext:
+    """Crea e restituisce il contesto applicativo condiviso dal bot."""
+
+    bot = _create_bot(token)
+    dispatcher = _create_dispatcher()
+    mongo_client, db_manager = _create_mongo_manager(mongo_uri, database_name)
+    notification_service = _create_notification_service(
+        bot,
+        admin_ids,
+        admin_channel_id,
+        owner_id,
+    )
+    scheduler = _create_scheduler(scheduler_timezone)
+
+    return BotAppContext(
+        bot=bot,
+        dispatcher=dispatcher,
+        notification_service=notification_service,
+        db_manager=db_manager,
+        scheduler=scheduler,
+        mongo_client=mongo_client,
+    )

--- a/bot_app/scheduler.py
+++ b/bot_app/scheduler.py
@@ -1,0 +1,80 @@
+"""Centralized scheduler configuration for Wolvesville bot jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from services.identity_service import IdentityService
+from services.maintenance_service import MaintenanceService
+from services.mission_service import MissionService
+
+
+def setup_scheduler(
+    scheduler: AsyncIOScheduler,
+    *,
+    maintenance_service: MaintenanceService,
+    mission_service: MissionService,
+    identity_service: IdentityService,
+    profile_auto_sync_minutes: int,
+    logger,
+) -> AsyncIOScheduler:
+    """Register periodic jobs executed by the shared scheduler."""
+
+    scheduler.add_job(
+        mission_service.send_weekly_mission_skin,
+        "cron",
+        day_of_week="mon",
+        hour=8,
+        minute=0,
+        timezone="Europe/Rome",
+    )
+
+    scheduler.add_job(
+        maintenance_service.process_ledger,
+        "interval",
+        minutes=5,
+        next_run_time=datetime.now(),
+    )
+
+    scheduler.add_job(
+        mission_service.process_active_mission_auto,
+        "interval",
+        minutes=5,
+        next_run_time=datetime.now(),
+    )
+
+    scheduler.add_job(
+        maintenance_service.prepopulate_users,
+        "interval",
+        days=3,
+        next_run_time=datetime.now(),
+    )
+
+    scheduler.add_job(
+        identity_service.refresh_linked_profiles,
+        "interval",
+        minutes=profile_auto_sync_minutes,
+        next_run_time=datetime.now(),
+    )
+
+    scheduler.add_job(
+        maintenance_service.clean_duplicate_users,
+        "interval",
+        hours=24,
+        next_run_time=datetime.now(),
+    )
+
+    scheduler.add_job(
+        maintenance_service.check_clan_departures,
+        "interval",
+        hours=6,
+        next_run_time=datetime.now(),
+    )
+
+    if not scheduler.running:
+        scheduler.start()
+
+    logger.info("Scheduler configurato con tutte le funzioni di manutenzione.")
+    return scheduler
+

--- a/services/identity_service.py
+++ b/services/identity_service.py
@@ -1,0 +1,405 @@
+"""Servizio centralizzato per la gestione di profili e identità Telegram/Wolvesville."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict, Optional
+
+import aiohttp
+from aiogram import types
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramNotFound
+
+from services.notification_service import NotificationType
+
+
+def format_telegram_username(username: Optional[str]) -> str:
+    """Restituisce uno username Telegram formattato con @ oppure un segnaposto."""
+
+    if not username:
+        return "—"
+    cleaned = username.strip()
+    if not cleaned:
+        return "—"
+    return cleaned if cleaned.startswith("@") else f"@{cleaned}"
+
+
+def format_markdown_code(value: Optional[Any]) -> str:
+    """Formatta un valore come blocco inline oppure restituisce un segnaposto."""
+
+    if value is None:
+        return "—"
+    text = str(value).strip()
+    if not text or text == "—":
+        return "—"
+    safe = text.replace("`", "\\`")
+    return f"`{safe}`"
+
+
+def build_profile_snapshot(profile: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Estrae un sottoinsieme sicuro dei dati del profilo per logging e auditing."""
+
+    if not profile:
+        return None
+
+    snapshot: Dict[str, Any] = {
+        "telegram_id": profile.get("telegram_id"),
+        "telegram_username": profile.get("telegram_username"),
+        "game_username": profile.get("game_username"),
+        "wolvesville_id": profile.get("wolvesville_id"),
+    }
+
+    if profile.get("updated_at"):
+        snapshot["updated_at"] = profile.get("updated_at")
+    if profile.get("created_at"):
+        snapshot["created_at"] = profile.get("created_at")
+
+    verification = profile.get("verification")
+    if isinstance(verification, dict):
+        snapshot["verification"] = {
+            key: verification.get(key)
+            for key in ("status", "verified_at", "method", "code")
+            if verification.get(key) is not None
+        }
+
+    return snapshot
+
+
+class IdentityService:
+    """Gestisce sincronizzazione, risoluzione e notifiche relative ai profili utenti."""
+
+    def __init__(
+        self,
+        *,
+        bot,
+        db_manager,
+        wolvesville_api_key: str,
+        schedule_admin_notification: Callable[..., None],
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._bot = bot
+        self._db_manager = db_manager
+        self._wolvesville_api_key = wolvesville_api_key
+        self._schedule_admin_notification = schedule_admin_notification
+        self._logger = logger or logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Helper per notifiche e sincronizzazione
+    # ------------------------------------------------------------------
+    def handle_telegram_sync_result(
+        self, result: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Invia notifiche se cambia lo username Telegram e restituisce il profilo."""
+
+        if not result:
+            return None
+
+        profile = result.get("profile")
+        if profile is None:
+            return None
+
+        if result.get("telegram_username_changed"):
+            game_username = profile.get("game_username")
+            if game_username:
+                old_username = format_telegram_username(
+                    result.get("previous_telegram_username")
+                )
+                new_username = format_telegram_username(profile.get("telegram_username"))
+                message = (
+                    "♻️ **Aggiornamento username Telegram**\n\n"
+                    f"🎮 **Giocatore:** {format_markdown_code(game_username)}\n"
+                    f"🆔 **Telegram ID:** {format_markdown_code(profile.get('telegram_id'))}\n"
+                    f"🔁 **Username:** {format_markdown_code(old_username)} → {format_markdown_code(new_username)}"
+                )
+                self._schedule_admin_notification(
+                    message,
+                    notification_type=NotificationType.INFO,
+                )
+
+        return profile
+
+    def handle_profile_link_result(
+        self, result: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Analizza il linking del profilo e notifica variazioni allo username di gioco."""
+
+        if not result or result.get("conflict"):
+            return result.get("profile") if result else None
+
+        profile = result.get("profile")
+        if profile is None:
+            return None
+
+        if result.get("game_username_changed") and result.get("previous_game_username"):
+            telegram_display = format_telegram_username(profile.get("telegram_username"))
+            message = (
+                "♻️ **Aggiornamento username Wolvesville**\n\n"
+                f"💬 **Telegram:** {format_markdown_code(telegram_display)}\n"
+                f"🆔 **Telegram ID:** {format_markdown_code(profile.get('telegram_id'))}\n"
+                f"🆔 **Wolvesville ID:** {format_markdown_code(profile.get('wolvesville_id'))}\n"
+                f"🔁 **Username:** {format_markdown_code(result.get('previous_game_username'))} → {format_markdown_code(profile.get('game_username'))}"
+            )
+            self._schedule_admin_notification(
+                message,
+                notification_type=NotificationType.INFO,
+            )
+
+        return profile
+
+    # ------------------------------------------------------------------
+    # API pubbliche
+    # ------------------------------------------------------------------
+    async def resolve_member_identity(self, username: Optional[str]) -> Dict[str, Any]:
+        """Risolvi uno username di gioco in base al profilo collegato."""
+
+        raw_username = username or ""
+        cleaned_username = raw_username.strip()
+
+        identity: Dict[str, Any] = {
+            "input_username": username,
+            "original_username": cleaned_username or None,
+            "resolved_username": cleaned_username or None,
+            "telegram_id": None,
+            "telegram_username": None,
+            "match": None,
+            "profile": None,
+            "profile_snapshot": None,
+        }
+
+        if not cleaned_username:
+            return identity
+
+        try:
+            resolution = await self._db_manager.resolve_profile_by_game_alias(
+                cleaned_username
+            )
+        except Exception as exc:  # pragma: no cover - log diagnostico
+            self._logger.warning(
+                "Impossibile risolvere il profilo per %s: %s",
+                cleaned_username,
+                exc,
+            )
+            return identity
+
+        if not resolution:
+            return identity
+
+        profile = resolution.get("profile") or {}
+        resolved_username = resolution.get("resolved_username") or cleaned_username
+
+        identity.update(
+            {
+                "resolved_username": resolved_username,
+                "match": resolution.get("match"),
+                "telegram_id": profile.get("telegram_id"),
+                "telegram_username": profile.get("telegram_username"),
+                "profile": profile,
+                "profile_snapshot": build_profile_snapshot(profile),
+            }
+        )
+
+        return identity
+
+    async def ensure_telegram_profile_synced(
+        self, user: Optional[types.User]
+    ) -> None:
+        """Allinea il profilo Telegram con il database e notifica eventuali cambi username."""
+
+        if user is None:
+            return
+
+        full_name_parts = [user.first_name or "", user.last_name or ""]
+        full_name = " ".join(part for part in full_name_parts if part).strip() or None
+
+        try:
+            result = await self._db_manager.sync_telegram_metadata(
+                user.id,
+                telegram_username=user.username,
+                full_name=full_name,
+            )
+        except Exception as exc:  # pragma: no cover - logging di sicurezza
+            self._logger.warning(
+                "Impossibile aggiornare il profilo Telegram per %s: %s",
+                getattr(user, "id", "?"),
+                exc,
+            )
+            return
+
+        if not result or result.get("created"):
+            return
+
+        self.handle_telegram_sync_result(result)
+        if (
+            result.get("telegram_username_changed")
+            and result.get("profile")
+        ):
+            profile = result["profile"]
+            game_username = profile.get("game_username")
+            if not game_username:
+                return
+            old_username = format_telegram_username(result.get("previous_telegram_username"))
+            new_username = format_telegram_username(profile.get("telegram_username"))
+            message = (
+                "♻️ **Aggiornamento username Telegram**\n\n"
+                f"🎮 **Giocatore:** {format_markdown_code(game_username)}\n"
+                f"🆔 **Telegram ID:** {format_markdown_code(profile.get('telegram_id'))}\n"
+                f"🔁 **Username:** {format_markdown_code(old_username)} → {format_markdown_code(new_username)}"
+            )
+            self._schedule_admin_notification(
+                message,
+                notification_type=NotificationType.INFO,
+            )
+
+    async def refresh_linked_profiles(self) -> None:
+        """Sincronizza periodicamente gli username Telegram e Wolvesville già collegati."""
+
+        try:
+            profiles = await self._db_manager.list_linked_player_profiles()
+        except Exception as exc:
+            self._logger.warning("Impossibile recuperare i profili collegati: %s", exc)
+            return
+
+        if not profiles:
+            return
+
+        async with aiohttp.ClientSession() as wolvesville_session:
+            for profile in profiles:
+                telegram_id = profile.get("telegram_id")
+                if not telegram_id:
+                    continue
+
+                latest_profile = profile
+
+                try:
+                    chat = await self._bot.get_chat(telegram_id)
+                except TelegramForbiddenError:
+                    self._logger.debug(
+                        "Sync Telegram ignorato per %s: bot bloccato", telegram_id
+                    )
+                except TelegramNotFound:
+                    self._logger.debug(
+                        "Sync Telegram ignorato per %s: utente non trovato", telegram_id
+                    )
+                except TelegramBadRequest as exc:
+                    self._logger.debug(
+                        "Sync Telegram fallito per %s: %s", telegram_id, exc
+                    )
+                else:
+                    chat_full_name = (
+                        " ".join(
+                            part
+                            for part in [chat.first_name, chat.last_name]
+                            if part
+                        ).strip()
+                        or None
+                    )
+                    try:
+                        result = await self._db_manager.sync_telegram_metadata(
+                            telegram_id,
+                            telegram_username=chat.username,
+                            full_name=chat_full_name,
+                        )
+                    except Exception as exc:  # pragma: no cover - diagnosi schedulatore
+                        self._logger.warning(
+                            "Sync Telegram fallito per %s: %s", telegram_id, exc
+                        )
+                    else:
+                        updated_profile = self.handle_telegram_sync_result(result)
+                        if updated_profile:
+                            latest_profile = updated_profile
+
+                wolvesville_id = (
+                    latest_profile.get("wolvesville_id")
+                    if isinstance(latest_profile, dict)
+                    else profile.get("wolvesville_id")
+                )
+                if not wolvesville_id:
+                    continue
+
+                player_info = await self.fetch_player_by_id(
+                    wolvesville_id,
+                    session=wolvesville_session,
+                )
+                if not player_info:
+                    continue
+
+                new_username = player_info.get("username")
+                if not new_username:
+                    continue
+
+                try:
+                    link_result = await self._db_manager.link_player_profile(
+                        telegram_id,
+                        game_username=new_username,
+                        telegram_username=latest_profile.get("telegram_username")
+                        if isinstance(latest_profile, dict)
+                        else profile.get("telegram_username"),
+                        full_name=latest_profile.get("full_name")
+                        if isinstance(latest_profile, dict)
+                        else profile.get("full_name"),
+                        wolvesville_id=wolvesville_id,
+                        verified=False,
+                        verification_code=None,
+                        verification_method=None,
+                    )
+                except Exception as exc:
+                    self._logger.warning(
+                        "Aggiornamento profilo Wolvesville fallito per %s: %s",
+                        telegram_id,
+                        exc,
+                    )
+                    continue
+
+                if link_result and link_result.get("conflict"):
+                    self._logger.warning(
+                        "Conflitto durante l'aggiornamento del profilo per %s: %s",
+                        telegram_id,
+                        link_result.get("reason"),
+                    )
+                    continue
+
+                updated_profile = self.handle_profile_link_result(link_result)
+                if updated_profile:
+                    latest_profile = updated_profile
+
+                await asyncio.sleep(0.1)
+
+    async def fetch_player_by_id(
+        self,
+        player_id: str,
+        *,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Recupera un giocatore tramite ID Wolvesville."""
+
+        if not player_id:
+            return None
+
+        url = f"https://api.wolvesville.com/players/{player_id}"
+        headers = {
+            "Authorization": f"Bot {self._wolvesville_api_key}",
+            "Accept": "application/json",
+        }
+
+        async def _do_request(client: aiohttp.ClientSession) -> Optional[Dict[str, Any]]:
+            async with client.get(url, headers=headers) as response:
+                if response.status != 200:
+                    self._logger.warning(
+                        "Impossibile recuperare il giocatore con ID %s (status %s)",
+                        player_id,
+                        response.status,
+                    )
+                    return None
+                return await response.json()
+
+        try:
+            if session is not None:
+                return await _do_request(session)
+            async with aiohttp.ClientSession() as owned_session:
+                return await _do_request(owned_session)
+        except Exception as exc:
+            self._logger.error(
+                "Errore durante il recupero del giocatore %s: %s", player_id, exc
+            )
+            return None
+

--- a/services/init.py
+++ b/services/init.py
@@ -3,6 +3,14 @@ Services package per il bot Telegram Wolvesville
 Contiene servizi per notifiche, API, statistiche, calendar, etc.
 """
 
+from .identity_service import IdentityService
+from .maintenance_service import MaintenanceService
+from .mission_service import MissionService
 from .notification_service import NotificationService
 
-__all__ = ['NotificationService']
+__all__ = [
+    "NotificationService",
+    "IdentityService",
+    "MaintenanceService",
+    "MissionService",
+]

--- a/services/maintenance_service.py
+++ b/services/maintenance_service.py
@@ -1,0 +1,308 @@
+"""Servizio per la manutenzione del database e la gestione del ledger."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Sequence
+
+import aiohttp
+
+from services.identity_service import IdentityService
+
+
+class MaintenanceService:
+    """Accorpa housekeeping del database e gestione del ledger."""
+
+    def __init__(
+        self,
+        *,
+        bot,
+        db_manager,
+        identity_service: IdentityService,
+        clan_id: str,
+        wolvesville_api_key: str,
+        admin_ids: Sequence[int],
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._bot = bot
+        self._db_manager = db_manager
+        self._identity_service = identity_service
+        self._clan_id = clan_id
+        self._wolvesville_api_key = wolvesville_api_key
+        self._admin_ids = tuple(admin_ids)
+        self._logger = logger or logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Operazioni di housekeeping
+    # ------------------------------------------------------------------
+    async def clean_duplicate_users(self) -> None:
+        """Rimuove utenti duplicati dal database mantenendo log di riepilogo."""
+
+        try:
+            removed_info = await self._db_manager.remove_duplicate_users()
+        except Exception as exc:
+            self._logger.error("Errore durante pulizia duplicati: %s", exc)
+            return
+
+        total_removed = sum(item.get("removed", 0) for item in removed_info)
+        for item in removed_info:
+            username = item.get("username", "sconosciuto")
+            removed = item.get("removed", 0)
+            removed_ids = item.get("removed_ids", [])
+            self._logger.info(
+                "Eliminati %s duplicati per %s (documenti rimossi: %s)",
+                removed,
+                username,
+                removed_ids,
+            )
+
+        self._logger.info(
+            "Pulizia duplicati completata. Eliminati %s duplicati.", total_removed
+        )
+
+    async def check_clan_departures(self) -> None:
+        """Controlla membri usciti dal clan e gestisce debiti/pulizia."""
+
+        try:
+            url = f"https://api.wolvesville.com/clans/{self._clan_id}/members"
+            headers = {
+                "Authorization": f"Bot {self._wolvesville_api_key}",
+                "Accept": "application/json",
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, headers=headers) as response:
+                    if response.status != 200:
+                        self._logger.error(
+                            "Errore nel recupero membri clan: %s", response.status
+                        )
+                        return
+                    current_members = await response.json()
+        except Exception as exc:
+            self._logger.error(
+                "Errore durante recupero membri clan per controllo uscite: %s", exc
+            )
+            return
+
+        current_usernames = {
+            member.get("username")
+            for member in current_members
+            if isinstance(member, dict)
+            and isinstance(member.get("username"), str)
+            and member.get("username")
+        }
+
+        try:
+            db_users = await self._db_manager.list_users()
+        except Exception as exc:
+            self._logger.error("Errore nel recupero utenti da MongoDB: %s", exc)
+            return
+
+        users_removed = 0
+        debt_notifications = 0
+
+        for user in db_users:
+            username = user.get("username")
+            if not username or username in current_usernames:
+                continue
+
+            donazioni = user.get("donazioni", {})
+            oro = donazioni.get("Oro", 0)
+            gem = donazioni.get("Gem", 0)
+
+            try:
+                oro = int(oro) if oro is not None else 0
+                gem = int(gem) if gem is not None else 0
+            except (ValueError, TypeError):
+                oro = gem = 0
+
+            if oro < 0 or gem < 0:
+                debt_message = (
+                    f"🚨 <b>USCITA CON DEBITI</b> 🚨\n\n"
+                    f"👤 <b>Utente:</b> {username}\n"
+                    f"💰 <b>Debito Oro:</b> {abs(oro) if oro < 0 else 0:,}\n"
+                    f"💎 <b>Debito Gem:</b> {abs(gem) if gem < 0 else 0:,}\n\n"
+                    f"⚠️ L'utente ha abbandonato il clan con debiti non saldati!\n"
+                    f"📅 Data controllo: {datetime.now().strftime('%d/%m/%Y %H:%M')}"
+                )
+
+                for admin_id in self._admin_ids:
+                    try:
+                        await self._bot.send_message(
+                            admin_id, debt_message, parse_mode="HTML"
+                        )
+                        debt_notifications += 1
+                    except Exception as exc:
+                        self._logger.warning(
+                            "Impossibile inviare notifica debito ad admin %s: %s",
+                            admin_id,
+                            exc,
+                        )
+
+                self._logger.info(
+                    "Notificato debito per utente uscito: %s (Oro: %s, Gem: %s)",
+                    username,
+                    oro,
+                    gem,
+                )
+                continue
+
+            try:
+                removed = await self._db_manager.remove_user_by_username(username)
+            except Exception as exc:
+                self._logger.warning(
+                    "Impossibile rimuovere l'utente %s dal database: %s",
+                    username,
+                    exc,
+                )
+                continue
+
+            if removed > 0:
+                users_removed += 1
+                self._logger.info(
+                    "Utente %s rimosso dal database (nessun debito)", username
+                )
+
+        self._logger.info(
+            "Controllo uscite clan completato: %s utenti rimossi, %s notifiche debiti inviate",
+            users_removed,
+            debt_notifications,
+        )
+
+    async def prepopulate_users(self) -> None:
+        """Pre-popolazione utenti dal clan con controllo duplicati."""
+
+        url = f"https://api.wolvesville.com/clans/{self._clan_id}/members"
+        headers = {
+            "Authorization": f"Bot {self._wolvesville_api_key}",
+            "Accept": "application/json",
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                if response.status != 200:
+                    self._logger.error(
+                        "Errore nel recupero dei membri: %s", response.status
+                    )
+                    return
+                members = await response.json()
+
+        for member in members:
+            username = None
+            if isinstance(member, dict):
+                username = member.get("username")
+            if username:
+                try:
+                    inserted = await self._db_manager.ensure_user(username)
+                except Exception as exc:
+                    self._logger.warning(
+                        "Impossibile pre-popolare l'utente %s: %s", username, exc
+                    )
+                    continue
+                if inserted:
+                    self._logger.info(
+                        "Utente %s pre-popolato con bilancio 0.", username
+                    )
+
+    # ------------------------------------------------------------------
+    # Gestione ledger
+    # ------------------------------------------------------------------
+    async def update_user_balance(
+        self, username: str, currency: str, amount: int
+    ) -> str:
+        """Aggiorna il bilancio dell'utente e restituisce la valuta normalizzata."""
+
+        normalized_currency = await self._db_manager.update_user_balance(
+            username, currency, amount
+        )
+        self._logger.info(
+            "Aggiornato bilancio per %s: %s %+d",
+            username,
+            normalized_currency,
+            amount,
+        )
+        return normalized_currency
+
+    async def process_ledger(self) -> None:
+        """Recupera il ledger e aggiorna il DB con i record DONATE non processati."""
+
+        url = f"https://api.wolvesville.com/clans/{self._clan_id}/ledger"
+        headers = {
+            "Authorization": f"Bot {self._wolvesville_api_key}",
+            "Accept": "application/json",
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                if response.status != 200:
+                    self._logger.error(
+                        "Errore nel recupero del ledger: %s", response.status
+                    )
+                    return
+                ledger_data = await response.json()
+
+        for record in ledger_data:
+            record_id = record.get("id")
+            record_type = record.get("type", "")
+            if record_type != "DONATE":
+                continue
+
+            if await self._db_manager.has_processed_ledger(record_id):
+                continue
+
+            username = record.get("playerUsername")
+            gold_amount = record.get("gold", 0) or 0
+            gems_amount = record.get("gems", 0) or 0
+
+            if username and (gold_amount > 0 or gems_amount > 0):
+                identity = await self._identity_service.resolve_member_identity(username)
+                resolved_username = identity.get("resolved_username")
+                if not resolved_username:
+                    self._logger.warning(
+                        "Record ledger %s ignorato: username non valido (%s)",
+                        record_id,
+                        username,
+                    )
+                    await self._db_manager.mark_ledger_processed(
+                        record_id, raw_record=record
+                    )
+                    continue
+
+                original_username = identity.get("original_username") or username
+                if (
+                    identity.get("match") == "history"
+                    and original_username
+                    and original_username != resolved_username
+                ):
+                    self._logger.info(
+                        "Ledger: risolto alias %s → %s (record %s)",
+                        original_username,
+                        resolved_username,
+                        record_id,
+                    )
+
+                if gold_amount > 0:
+                    await self.update_user_balance(
+                        resolved_username, "Oro", gold_amount
+                    )
+                if gems_amount > 0:
+                    await self.update_user_balance(
+                        resolved_username, "Gem", gems_amount
+                    )
+
+                await self._db_manager.log_donation(
+                    record_id,
+                    resolved_username,
+                    gold_amount,
+                    gems_amount,
+                    raw_record=record,
+                    telegram_id=identity.get("telegram_id"),
+                    telegram_username=identity.get("telegram_username"),
+                    profile_snapshot=identity.get("profile_snapshot"),
+                    original_username=original_username,
+                    match_source=identity.get("match"),
+                )
+
+            await self._db_manager.mark_ledger_processed(record_id, raw_record=record)
+

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -1,0 +1,854 @@
+"""Mission management service for Wolvesville bot."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+import aiohttp
+from aiogram import Bot, Dispatcher, F, types
+from aiogram.filters import Command
+from aiogram.filters.state import StateFilter
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from services.db_manager import MongoManager
+from services.identity_service import IdentityService
+from services.maintenance_service import MaintenanceService
+
+
+class MissionStates(StatesGroup):
+    """Finite state machine for the /partecipanti flow."""
+
+    SELECTING_MISSION = State()
+    CONFIRMING_PARTICIPANTS = State()
+
+
+@dataclass(slots=True)
+class MissionService:
+    """Coordinate Wolvesville mission processing and history logging."""
+
+    bot: Bot
+    db_manager: MongoManager
+    identity_service: IdentityService
+    maintenance_service: MaintenanceService
+    wolvesville_api_key: str
+    clan_id: str
+    logger: logging.Logger
+    clan_chat_id: Optional[int] = None
+    clan_topic_id: Optional[int] = None
+
+    # ---------------------------------------------------------------------
+    # Public API used by other components (scheduler, commands, services)
+    # ---------------------------------------------------------------------
+    async def process_mission(
+        self,
+        participants: Sequence[str],
+        mission_type: str,
+        *,
+        mission_id: Optional[str] = None,
+        outcome: str = "processed",
+        source: str = "manual",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Apply mission costs, resolve participants and log the event."""
+
+        if not participants:
+            self.logger.info(
+                "Processo missione %s saltato: nessun partecipante fornito.",
+                mission_type,
+            )
+            return None
+
+        mission_type = mission_type or "Unknown"
+        mission_type_lower = mission_type.lower()
+
+        resolved_identities: List[Dict[str, Any]] = []
+        alias_resolved_count = 0
+        unresolved_participants: List[str] = []
+
+        for participant in participants:
+            identity = await self.identity_service.resolve_member_identity(participant)
+            resolved_username = identity.get("resolved_username")
+            if not resolved_username:
+                self.logger.warning(
+                    "Missione %s: ignorato partecipante senza username valido (%s)",
+                    mission_type,
+                    participant,
+                )
+                unresolved_participants.append(participant)
+                continue
+            if (
+                identity.get("match") == "history"
+                and identity.get("original_username")
+                and identity.get("original_username") != resolved_username
+            ):
+                alias_resolved_count += 1
+                self.logger.info(
+                    "Missione %s: alias risolto %s → %s",
+                    mission_type,
+                    identity.get("original_username"),
+                    resolved_username,
+                )
+            resolved_identities.append(identity)
+
+        if not resolved_identities:
+            self.logger.info(
+                "Processo missione %s saltato: nessun partecipante risolto.",
+                mission_type,
+            )
+            return None
+
+        original_participant_count = len(participants)
+        participant_count = len(resolved_identities)
+        unresolved_count = max(original_participant_count - participant_count, 0)
+
+        cost = 0
+        currency_key = mission_type
+
+        if mission_type_lower == "gold":
+            cost = 500
+            currency_key = "Gold"
+        elif mission_type_lower == "gem":
+            if participant_count > 7:
+                cost = 140
+            elif 5 <= participant_count <= 7:
+                cost = 150
+            else:
+                cost = 0
+            currency_key = "Gem"
+
+        if cost != 0:
+            for identity in resolved_identities:
+                await self.maintenance_service.update_user_balance(
+                    identity["resolved_username"], currency_key, -cost
+                )
+            self.logger.info(
+                "Applicato costo di %s %s a %s partecipanti (missione %s).",
+                cost,
+                "Oro" if mission_type_lower == "gold" else "Gem",
+                participant_count,
+                mission_type,
+            )
+            if alias_resolved_count:
+                self.logger.info(
+                    "Missione %s: %s partecipanti provenivano da alias storici.",
+                    mission_type,
+                    alias_resolved_count,
+                )
+        else:
+            self.logger.info(
+                "Registrata missione %s senza costi aggiuntivi per %s partecipanti.",
+                mission_type,
+                participant_count,
+            )
+
+        metadata_payload = dict(metadata or {})
+        metadata_payload.setdefault("participants_count", original_participant_count)
+        metadata_payload.setdefault("cost_applied", cost)
+        metadata_payload["resolved_participants_count"] = participant_count
+        metadata_payload["unresolved_participants_count"] = unresolved_count
+        metadata_payload["alias_resolutions"] = alias_resolved_count
+        metadata_payload["linked_participants"] = sum(
+            1 for identity in resolved_identities if identity.get("telegram_id")
+        )
+        if unresolved_participants:
+            metadata_payload["unresolved_participants"] = unresolved_participants
+
+        participant_entries: List[Dict[str, Any]] = []
+        for identity in resolved_identities:
+            entry: Dict[str, Any] = {
+                "username": identity.get("resolved_username"),
+                "original_username": identity.get("original_username"),
+            }
+            if identity.get("telegram_id") is not None:
+                entry["telegram_id"] = identity.get("telegram_id")
+            if identity.get("telegram_username"):
+                entry["telegram_username"] = identity.get("telegram_username")
+            if identity.get("match"):
+                entry["match"] = identity.get("match")
+            if identity.get("profile_snapshot"):
+                entry["profile_snapshot"] = identity.get("profile_snapshot")
+            participant_entries.append(entry)
+
+        event_id = await self.db_manager.log_mission_participation(
+            mission_id,
+            mission_type,
+            participant_entries,
+            list(participants),
+            cost_per_participant=cost,
+            outcome=outcome,
+            source=source,
+            metadata=metadata_payload,
+        )
+
+        if event_id:
+            self.logger.info(
+                "Registrata partecipazione missione %s (event_id=%s) con %s partecipanti.",
+                mission_id or "manual",
+                event_id,
+                participant_count,
+            )
+
+        return event_id
+
+    async def process_active_mission_auto(self) -> None:
+        """Resolve the currently active mission, apply costs and store history."""
+
+        url = f"https://api.wolvesville.com/clans/{self.clan_id}/quests/active"
+        headers = {
+            "Authorization": f"Bot {self.wolvesville_api_key}",
+            "Accept": "application/json",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    self.logger.error(
+                        "Errore nel recupero della missione attiva: %s", resp.status
+                    )
+                    return
+                active_data = await resp.json()
+
+        quest = active_data.get("quest")
+        if not quest:
+            self.logger.info("Nessuna missione attiva trovata.")
+            return
+
+        mission_id = quest.get("id")
+        tier_start_time = active_data.get("tierStartTime")
+        if not mission_id or not tier_start_time:
+            self.logger.error("Missione attiva priva di id o tierStartTime.")
+            return
+
+        if await self.db_manager.has_processed_active_mission(mission_id):
+            self.logger.info(
+                "Missione %s già processata. Nessuna operazione eseguita.", mission_id
+            )
+            return
+
+        participants = active_data.get("participants", [])
+        raw_usernames = [p.get("username") for p in participants if p.get("username")]
+        if not raw_usernames:
+            self.logger.info("Nessun partecipante trovato nella missione attiva.")
+            return
+
+        resolved_identities: List[Dict[str, Any]] = []
+        alias_resolved_count = 0
+        unresolved_usernames: List[str] = []
+        for username in raw_usernames:
+            identity = await self.identity_service.resolve_member_identity(username)
+            resolved_username = identity.get("resolved_username")
+            if not resolved_username:
+                self.logger.warning(
+                    "Missione attiva %s: ignorato username non valido (%s)",
+                    mission_id,
+                    username,
+                )
+                unresolved_usernames.append(username)
+                continue
+            if (
+                identity.get("match") == "history"
+                and identity.get("original_username")
+                and identity.get("original_username") != resolved_username
+            ):
+                alias_resolved_count += 1
+                self.logger.info(
+                    "Missione attiva %s: alias risolto %s → %s",
+                    mission_id,
+                    identity.get("original_username"),
+                    resolved_username,
+                )
+            resolved_identities.append(identity)
+
+        if not resolved_identities:
+            self.logger.info(
+                "Missione %s: nessun partecipante valido dopo la risoluzione.",
+                mission_id,
+            )
+            return
+
+        participant_count = len(resolved_identities)
+
+        mission_type = "Gem" if quest.get("purchasableWithGems", False) else "Gold"
+        if mission_type == "Gold":
+            cost = 500
+        else:
+            if participant_count > 7:
+                cost = 140
+            elif 5 <= participant_count <= 7:
+                cost = 150
+            else:
+                cost = 0
+
+        if cost:
+            for identity in resolved_identities:
+                await self.maintenance_service.update_user_balance(
+                    identity["resolved_username"], mission_type, -cost
+                )
+                log_name = identity.get("resolved_username")
+                original = identity.get("original_username")
+                if original and original != log_name:
+                    self.logger.info(
+                        "Dedotto %s %s per %s (alias %s) nella missione %s",
+                        cost,
+                        "Oro" if mission_type == "Gold" else "Gem",
+                        log_name,
+                        original,
+                        mission_id,
+                    )
+                else:
+                    self.logger.info(
+                        "Dedotto %s %s per %s nella missione %s",
+                        cost,
+                        "Oro" if mission_type == "Gold" else "Gem",
+                        log_name,
+                        mission_id,
+                    )
+        else:
+            self.logger.info(
+                "Missione attiva %s registrata senza costi aggiuntivi.",
+                mission_id,
+            )
+
+        metadata = {
+            "tier_start_time": tier_start_time,
+            "participants_count": len(raw_usernames),
+            "resolved_participants_count": participant_count,
+            "alias_resolutions": alias_resolved_count,
+            "linked_participants": sum(
+                1 for identity in resolved_identities if identity.get("telegram_id")
+            ),
+            "cost_applied": cost,
+        }
+        if unresolved_usernames:
+            metadata["unresolved_participants"] = unresolved_usernames
+            metadata["unresolved_participants_count"] = len(unresolved_usernames)
+        else:
+            metadata["unresolved_participants_count"] = 0
+
+        participant_entries: List[Dict[str, Any]] = []
+        for identity in resolved_identities:
+            entry: Dict[str, Any] = {
+                "username": identity.get("resolved_username"),
+                "original_username": identity.get("original_username"),
+            }
+            if identity.get("telegram_id") is not None:
+                entry["telegram_id"] = identity.get("telegram_id")
+            if identity.get("telegram_username"):
+                entry["telegram_username"] = identity.get("telegram_username")
+            if identity.get("match"):
+                entry["match"] = identity.get("match")
+            if identity.get("profile_snapshot"):
+                entry["profile_snapshot"] = identity.get("profile_snapshot")
+            participant_entries.append(entry)
+
+        event_id = await self.db_manager.log_mission_participation(
+            mission_id,
+            mission_type,
+            participant_entries,
+            raw_usernames,
+            cost_per_participant=cost,
+            outcome="auto_processed",
+            source="active_mission",
+            metadata=metadata,
+        )
+
+        await self.db_manager.mark_active_mission_processed(mission_id, tier_start_time)
+        self.logger.info(
+            "Missione %s processata e registrata (event_id=%s).",
+            mission_id,
+            event_id or "N/A",
+        )
+
+    async def send_weekly_mission_skin(self) -> None:
+        """Announce weekly missions and post the available skins."""
+
+        if self.clan_chat_id is None:
+            self.logger.warning(
+                "CHAT_ID non configurato, impossibile inviare l'annuncio settimanale."
+            )
+            return
+
+        url = f"https://api.wolvesville.com/clans/{self.clan_id}/quests/available"
+        announcement_message = (
+            "🌞 Buongiorno Ragazzi e Ragazze!\n\n"
+            "Qui il bot ad avvisarvi che oggi è **Lunedì**!!\n\n"
+            "Giornata peggiore, ma per fortuna ci sono nuove missioni.\n"
+            "Quindi andate a **votare**! 🗳️🔥"
+        )
+
+        try:
+            await self.bot.send_message(
+                chat_id=self.clan_chat_id,
+                text=announcement_message,
+                message_thread_id=self.clan_topic_id,
+            )
+
+            url_announcement = (
+                f"https://api.wolvesville.com/clans/{self.clan_id}/announcements"
+            )
+            async with aiohttp.ClientSession() as session:
+                headers = {
+                    "Authorization": f"Bot {self.wolvesville_api_key}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                }
+                payload = {"message": announcement_message}
+                async with session.post(
+                    url_announcement, headers=headers, json=payload
+                ) as resp:
+                    if resp.status in [200, 201, 204]:
+                        self.logger.info("Annuncio inviato con successo nel gioco!")
+                    else:
+                        response_text = await resp.text()
+                        self.logger.error(
+                            "Errore nell'invio dell'annuncio: %s (Codice: %s)",
+                            response_text,
+                            resp.status,
+                        )
+
+            async with aiohttp.ClientSession() as session:
+                headers = {
+                    "Authorization": f"Bot {self.wolvesville_api_key}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                }
+                resp = await session.get(url, headers=headers)
+                if resp.status != 200:
+                    self.logger.error(
+                        "Errore nel recupero delle skin programmate (status %s)",
+                        resp.status,
+                    )
+                    return
+                data = await resp.json()
+                if not data:
+                    self.logger.info(
+                        "Nessuna skin disponibile per l'invio automatico"
+                    )
+                    return
+
+                for quest in data:
+                    promo_url = quest.get("promoImageUrl", "")
+                    is_gem = quest.get("purchasableWithGems", False)
+                    name = "Sconosciuto"
+                    if promo_url:
+                        filename = promo_url.split("/")[-1]
+                        name = filename.split(".")[0]
+                    tipo_str = "Gem" if is_gem else "Gold"
+                    caption = f"Nome: {name}\nTipo: {tipo_str}"
+
+                    if not promo_url:
+                        continue
+
+                    try:
+                        async with session.get(promo_url) as r_img:
+                            if r_img.status == 200:
+                                raw = await r_img.read()
+                                skin_file = types.BufferedInputFile(
+                                    raw, filename="skin.png"
+                                )
+                                await self.bot.send_photo(
+                                    chat_id=self.clan_chat_id,
+                                    photo=skin_file,
+                                    caption=caption,
+                                    message_thread_id=self.clan_topic_id,
+                                )
+                    except Exception as exc:  # pragma: no cover - solo logging
+                        self.logger.warning(
+                            "Impossibile inviare %s: %s", promo_url, exc
+                        )
+        except Exception as exc:  # pragma: no cover - solo logging
+            self.logger.error(
+                "Errore nell'invio automatico delle skin: %s", exc
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers used by the /partecipanti FSM flow
+    # ------------------------------------------------------------------
+    async def get_available_missions(self) -> List[Dict[str, Any]]:
+        url = f"https://api.wolvesville.com/clans/{self.clan_id}/quests/available"
+        async with aiohttp.ClientSession() as session:
+            headers = {
+                "Authorization": f"Bot {self.wolvesville_api_key}",
+                "Accept": "application/json",
+            }
+            async with session.get(url, headers=headers) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+                self.logger.error(
+                    "Errore nel recupero delle missioni: status %s",
+                    resp.status,
+                )
+                return []
+
+    async def get_clan_member_ids(
+        self, session: Optional[aiohttp.ClientSession] = None
+    ) -> List[str]:
+        close_session = False
+        members: List[Dict[str, Any]] = []
+
+        if session is None:
+            session = aiohttp.ClientSession()
+            close_session = True
+
+        try:
+            url = f"https://api.wolvesville.com/clans/{self.clan_id}/members"
+            headers = {
+                "Authorization": f"Bot {self.wolvesville_api_key}",
+                "Accept": "application/json",
+            }
+            async with session.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    error_body = await resp.text()
+                    self.logger.error(
+                        "Errore nel recupero dei membri del clan: status %s, risposta %s",
+                        resp.status,
+                        error_body,
+                    )
+                    return []
+
+                data = await resp.json()
+                if isinstance(data, list):
+                    members = data
+                elif isinstance(data, dict):
+                    members_value = data.get("members", [])
+                    if isinstance(members_value, list):
+                        members = members_value
+                    else:
+                        self.logger.error(
+                            "Formato inatteso nella risposta dei membri del clan: %s",
+                            data,
+                        )
+                        return []
+                else:
+                    self.logger.error(
+                        "Formato inatteso nella risposta dei membri del clan: %s",
+                        data,
+                    )
+                    return []
+        except Exception as exc:  # pragma: no cover - solo logging
+            self.logger.error(
+                "Eccezione durante il recupero dei membri del clan: %s", exc
+            )
+            return []
+        finally:
+            if close_session:
+                await session.close()
+
+        member_ids: List[str] = []
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+
+            member_id = (
+                member.get("playerId")
+                or member.get("id")
+                or member.get("memberId")
+                or member.get("userId")
+            )
+
+            if not member_id:
+                player_data = member.get("player")
+                if isinstance(player_data, dict):
+                    member_id = (
+                        player_data.get("playerId")
+                        or player_data.get("id")
+                        or player_data.get("userId")
+                    )
+
+            if member_id:
+                member_ids.append(str(member_id))
+            else:
+                self.logger.warning(
+                    "Impossibile determinare l'ID per il membro: %s", member
+                )
+
+        unique_member_ids = list(dict.fromkeys(member_ids))
+        if not unique_member_ids:
+            self.logger.warning(
+                "Nessun ID valido trovato nella lista dei membri del clan."
+            )
+
+        return unique_member_ids
+
+    async def partecipanti_command(
+        self, message: types.Message, state: FSMContext
+    ) -> None:
+        missions = await self.get_available_missions()
+        if not missions:
+            await message.answer("Nessuna missione disponibile al momento.")
+            return
+
+        buttons = []
+        for mission in missions:
+            promo_url = mission.get("promoImageUrl", "")
+            name = "Sconosciuto"
+            if promo_url:
+                filename = promo_url.split("/")[-1]
+                name = filename.split(".")[0]
+            mission_id = mission.get("id")
+            buttons.append(
+                [
+                    InlineKeyboardButton(
+                        text=name, callback_data=f"mission_select_{mission_id}"
+                    )
+                ]
+            )
+        kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+        await message.answer(
+            "Per quale missione si intende abilitare i partecipanti?",
+            reply_markup=kb,
+        )
+        await state.update_data(available_missions=missions)
+        await state.set_state(MissionStates.SELECTING_MISSION)
+
+    async def mission_select_callback(
+        self, callback: types.CallbackQuery, state: FSMContext
+    ) -> None:
+        selected_mission_id = callback.data.split("mission_select_")[-1]
+        try:
+            await callback.message.delete()
+        except Exception as exc:  # pragma: no cover - solo logging
+            self.logger.warning(
+                "Errore nella cancellazione del messaggio: %s", exc
+            )
+
+        votes_url = f"https://api.wolvesville.com/clans/{self.clan_id}/quests/votes"
+        async with aiohttp.ClientSession() as session:
+            headers = {
+                "Authorization": f"Bot {self.wolvesville_api_key}",
+                "Accept": "application/json",
+            }
+            async with session.get(votes_url, headers=headers) as resp:
+                if resp.status != 200:
+                    await callback.message.answer("Impossibile recuperare i voti.")
+                    return
+                votes_data = await resp.json()
+
+        votes_dict = votes_data.get("votes", {})
+        mission_player_ids = votes_dict.get(selected_mission_id, [])
+        self.logger.info(
+            "Numero di voti per missione %s: %s",
+            selected_mission_id,
+            len(mission_player_ids),
+        )
+        await state.update_data(
+            selected_mission_id=selected_mission_id,
+            mission_player_ids=mission_player_ids,
+        )
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text="Si",
+                        callback_data=f"enable_votes_yes_{selected_mission_id}",
+                    ),
+                    InlineKeyboardButton(
+                        text="No",
+                        callback_data=f"enable_votes_no_{selected_mission_id}",
+                    ),
+                ]
+            ]
+        )
+        await callback.message.answer(
+            "Vuoi abilitare i partecipanti che hanno votato per questa missione?",
+            reply_markup=kb,
+        )
+        await state.set_state(MissionStates.CONFIRMING_PARTICIPANTS)
+
+    async def enable_votes_callback(
+        self, callback: types.CallbackQuery, state: FSMContext
+    ) -> None:
+        parts = callback.data.split("_")
+        decision = parts[2]
+        try:
+            await callback.message.delete()
+        except Exception as exc:  # pragma: no cover - solo logging
+            self.logger.warning(
+                "Errore nella cancellazione del messaggio: %s", exc
+            )
+
+        if decision == "yes":
+            data = await state.get_data()
+            mission_player_ids_raw = data.get("mission_player_ids", [])
+            selected_mission_id = data.get("selected_mission_id")
+
+            mission_player_ids = [str(pid) for pid in mission_player_ids_raw]
+            mission_player_ids = list(dict.fromkeys(mission_player_ids))
+
+            self.logger.info(
+                "Missione %s: abilito %s partecipanti dal voto",
+                selected_mission_id,
+                len(mission_player_ids),
+            )
+
+            if not mission_player_ids:
+                await callback.message.answer(
+                    "Nessun partecipante da abilitare per questa missione."
+                )
+                await state.clear()
+                return
+
+            if not selected_mission_id:
+                await callback.message.answer(
+                    "Sessione non valida, ripeti /partecipanti."
+                )
+                await state.clear()
+                return
+
+            disable_failures: List[str] = []
+            enable_failures: List[str] = []
+            warning_messages: List[str] = []
+
+            try:
+                async with aiohttp.ClientSession() as session:
+                    json_headers = {
+                        "Authorization": f"Bot {self.wolvesville_api_key}",
+                        "Content-Type": "application/json",
+                    }
+
+                    all_member_ids = await self.get_clan_member_ids(session)
+                    if all_member_ids:
+                        disable_payload = {"participateInQuests": False}
+                        for member_id in all_member_ids:
+                            url_put_disable = (
+                                f"https://api.wolvesville.com/clans/{self.clan_id}/members/{member_id}/participateInQuests"
+                            )
+                            async with session.put(
+                                url_put_disable,
+                                headers=json_headers,
+                                json=disable_payload,
+                            ) as resp:
+                                response_text = await resp.text()
+                                self.logger.info(
+                                    "PUT %s -> %s, %s",
+                                    url_put_disable,
+                                    resp.status,
+                                    response_text,
+                                )
+                                if resp.status not in [200, 201, 204]:
+                                    disable_failures.append(str(member_id))
+                                    self.logger.error(
+                                        "Errore nella disattivazione del membro %s: status %s, risposta %s",
+                                        member_id,
+                                        resp.status,
+                                        response_text,
+                                    )
+                    else:
+                        warning_messages.append(
+                            "⚠️ Impossibile recuperare la lista completa dei membri, salto la disattivazione preventiva."
+                        )
+                        self.logger.warning(
+                            "Lista membri vuota durante la disattivazione preventiva dei partecipanti alla missione."
+                        )
+
+                    enable_payload = {"participateInQuests": True}
+                    for pid in mission_player_ids:
+                        url_put_enable = (
+                            f"https://api.wolvesville.com/clans/{self.clan_id}/members/{pid}/participateInQuests"
+                        )
+                        async with session.put(
+                            url_put_enable,
+                            headers=json_headers,
+                            json=enable_payload,
+                        ) as resp:
+                            response_text = await resp.text()
+                            self.logger.info(
+                                "PUT %s -> %s, %s",
+                                url_put_enable,
+                                resp.status,
+                                response_text,
+                            )
+                            if resp.status not in [200, 201, 204]:
+                                enable_failures.append(str(pid))
+                                self.logger.error(
+                                    "Errore nell'abilitazione del membro %s: status %s, risposta %s",
+                                    pid,
+                                    resp.status,
+                                    response_text,
+                                )
+
+                    await callback.message.answer(
+                        "I partecipanti che hanno votato sono stati abilitati."
+                    )
+
+                    claim_url = (
+                        f"https://api.wolvesville.com/clans/{self.clan_id}/quests/claim"
+                    )
+                    claim_headers = {
+                        "Authorization": f"Bot {self.wolvesville_api_key}",
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                    }
+                    claim_payload = {"questId": selected_mission_id}
+
+                    async with session.post(
+                        claim_url, headers=claim_headers, json=claim_payload
+                    ) as resp:
+                        claim_body = await resp.text()
+                        if resp.status in [200, 201, 204]:
+                            await callback.message.answer(
+                                "🚀 Missione avviata con successo."
+                            )
+                            self.logger.info(
+                                "Missione %s avviata con successo: %s",
+                                selected_mission_id,
+                                claim_body,
+                            )
+                        else:
+                            self.logger.error(
+                                "Errore nell'avvio della missione %s: status %s, risposta %s",
+                                selected_mission_id,
+                                resp.status,
+                                claim_body,
+                            )
+                            await callback.message.answer(
+                                f"⚠️ Impossibile avviare la missione (status {resp.status})."
+                            )
+
+                    for message_text in warning_messages:
+                        await callback.message.answer(message_text)
+
+                    if disable_failures:
+                        await callback.message.answer(
+                            f"⚠️ Disattivazione non riuscita per {len(disable_failures)} membri. Controlla i log per i dettagli."
+                        )
+
+                    if enable_failures:
+                        await callback.message.answer(
+                            f"⚠️ Abilitazione non riuscita per {len(enable_failures)} partecipanti. Controlla i log per i dettagli."
+                        )
+            except Exception as exc:  # pragma: no cover - solo logging
+                self.logger.error(
+                    "Errore durante la gestione dell'abilitazione missione per %s: %s",
+                    selected_mission_id,
+                    exc,
+                )
+                await callback.message.answer(
+                    "Si è verificato un errore durante l'abilitazione dei partecipanti. Riprova più tardi."
+                )
+        else:
+            await callback.message.answer("Abilitazione annullata.")
+
+        await state.clear()
+
+    # ------------------------------------------------------------------
+    # Registration helpers
+    # ------------------------------------------------------------------
+    def register_handlers(self, dispatcher: Dispatcher) -> None:
+        dispatcher.message.register(
+            self.partecipanti_command, Command("partecipanti")
+        )
+        dispatcher.callback_query.register(
+            self.mission_select_callback,
+            StateFilter(MissionStates.SELECTING_MISSION),
+            F.data.startswith("mission_select_"),
+        )
+        dispatcher.callback_query.register(
+            self.enable_votes_callback,
+            StateFilter(MissionStates.CONFIRMING_PARTICIPANTS),
+            F.data.startswith("enable_votes_"),
+        )
+


### PR DESCRIPTION
## Summary
- add a dedicated identity service encapsulating profile resolution, synchronization and Wolvesville lookups
- introduce a maintenance service responsible for database housekeeping and ledger processing APIs
- refactor the bot bootstrap, scheduler configuration and handlers to depend on the new services and shared helpers
- extract a mission service that centralizes mission processing, history logging, weekly announcements and the /partecipanti FSM
- move the recurring job registration into a dedicated scheduler module that wires mission, maintenance and identity services

## Testing
- python -m compileall bot_app bot.py services

------
https://chatgpt.com/codex/tasks/task_e_68cab616f68c8323bfc75bcce62d1a66