### PR TITLE
Add donation and mission history aggregates

### DIFF
--- a/reward_service.py
+++ b/reward_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict, List, Optional
 
 from services.db_manager import MongoManager
@@ -129,6 +130,20 @@ class RewardService:
             {"$sort": {"reward_points": -1}},
             {"$limit": limit}
         ]
-        
+
         leaderboard = await self.db.aggregate_users(pipeline)
         return leaderboard
+
+    async def get_top_contributors(
+        self,
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        limit: int = 10,
+        currency: Optional[str] = None,
+    ) -> List[Dict]:
+        """Espone i donatori principali per la logica premi."""
+
+        return await self.db.get_top_donors(
+            limit=limit, start=start, end=end, currency=currency
+        )

--- a/statistics_service.py
+++ b/statistics_service.py
@@ -1,8 +1,7 @@
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
-from datetime import datetime, timedelta
-from typing import Dict, List
+from typing import Dict
 import io
 
 class StatisticsService:
@@ -10,45 +9,63 @@ class StatisticsService:
         self.db = db_manager
         
     async def generate_donation_trends(self, days: int = 30) -> io.BytesIO:
-        """Genera grafico trend donazioni ultimi N giorni"""
-        # Recupera dati donazioni
-        donations_data = await self.db.get_donation_history(days)
-        
+        """Genera un grafico temporale delle donazioni aggregate per valuta."""
+
+        donations_data = await self.db.get_donation_time_series(days=days)
         df = pd.DataFrame(donations_data)
-        
+
+        if df.empty:
+            df = pd.DataFrame(columns=["date", "gold", "gems", "donations"])
+
+        for column in ("gold", "gems", "donations"):
+            if column not in df:
+                df[column] = 0
+
+        if "date" in df:
+            try:
+                df["date"] = pd.to_datetime(df["date"], errors="coerce")
+            except Exception:  # pragma: no cover - conversione difensiva
+                pass
+            df = df.sort_values("date")
+
         fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
-        
-        # Grafico donazioni Oro nel tempo
-        df_oro = df.groupby('date')['oro'].sum()
-        ax1.plot(df_oro.index, df_oro.values, marker='o', color='gold')
-        ax1.set_title('Trend Donazioni Oro')
-        ax1.set_ylabel('Oro Donato')
-        
-        # Grafico donazioni Gem nel tempo  
-        df_gem = df.groupby('date')['gem'].sum()
-        ax2.plot(df_gem.index, df_gem.values, marker='o', color='purple')
-        ax2.set_title('Trend Donazioni Gem')
-        ax2.set_ylabel('Gem Donate')
-        
+
+        df_oro = df.groupby("date")["gold"].sum() if not df.empty else pd.Series(dtype=float)
+        ax1.plot(df_oro.index, df_oro.values, marker="o", color="gold")
+        ax1.set_title("Trend Donazioni Oro")
+        ax1.set_ylabel("Oro Donato")
+
+        df_gem = df.groupby("date")["gems"].sum() if not df.empty else pd.Series(dtype=float)
+        ax2.plot(df_gem.index, df_gem.values, marker="o", color="purple")
+        ax2.set_title("Trend Donazioni Gem")
+        ax2.set_ylabel("Gem Donate")
+
         plt.tight_layout()
-        
-        # Salva in buffer
+
         buffer = io.BytesIO()
-        plt.savefig(buffer, format='png', dpi=300, bbox_inches='tight')
+        plt.savefig(buffer, format="png", dpi=300, bbox_inches="tight")
         buffer.seek(0)
         plt.close()
-        
+
         return buffer
-        
+
     async def generate_participation_stats(self) -> Dict:
         """Genera statistiche partecipazione missioni"""
         missions_data = await self.db.get_mission_participation()
-        
+
+        total_missions = len(missions_data)
+        avg_participants = (
+            sum(m["participants"] for m in missions_data) / total_missions
+            if total_missions
+            else 0
+        )
+
         stats = {
-            "total_missions": len(missions_data),
-            "avg_participants": sum(m["participants"] for m in missions_data) / len(missions_data),
+            "total_missions": total_missions,
+            "avg_participants": avg_participants,
             "most_active_players": await self.db.get_top_participants(limit=10),
-            "mission_success_rate": await self.db.calculate_success_rate()
+            "mission_success_rate": await self.db.calculate_success_rate(),
+            "time_series": await self.db.get_mission_time_series(),
         }
-        
+
         return stats


### PR DESCRIPTION
## Summary
- add reusable helpers and aggregation APIs in the Mongo manager to expose donation and mission time series as well as top contributors
- capture ledger timestamps and propagate processed times when logging donations and missions so the history collections stay accurate
- update statistics and reward services to consume the new aggregated data providers for reporting and rewards

## Testing
- python -m compileall services statistics_service.py reward_service.py

------
https://chatgpt.com/codex/tasks/task_e_68cbd5ca94d8832392349e1bc0c8f450