### PR TITLE
fix: initialize rewards repo slots

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -37,6 +37,7 @@ except ImportError as exc:  # pragma: no cover - il progetto può funzionare sen
     LoggingMiddleware = None  # type: ignore
     MIDDLEWARE_AVAILABLE = False
 
+from reward_service import RewardService
 from services.identity_service import IdentityService
 from services.maintenance_service import MaintenanceService
 from services.mission_service import MissionService
@@ -68,6 +69,7 @@ notification_service: Optional[EnhancedNotificationService] = None
 identity_service: Optional[IdentityService] = None
 maintenance_service: Optional[MaintenanceService] = None
 mission_service: Optional[MissionService] = None
+reward_service: Optional[RewardService] = None
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +140,7 @@ dp = app_context.dispatcher
 notification_service = app_context.notification_service
 db_manager = app_context.db_manager
 scheduler = app_context.scheduler
+rewards_repository = app_context.rewards_repository
 
 identity_service = IdentityService(
     bot=bot,
@@ -164,6 +167,12 @@ mission_service = MissionService(
     maintenance_service=maintenance_service,
     wolvesville_api_key=WOLVESVILLE_API_KEY,
     clan_id=CLAN_ID,
+    logger=logger,
+)
+
+reward_service = RewardService(
+    repository=rewards_repository,
+    notification_service=notification_service,
     logger=logger,
 )
 
@@ -210,6 +219,7 @@ register_user_flow_handlers(
     admin_ids=ADMIN_IDS,
     authorized_groups=AUTHORIZED_GROUPS,
     schedule_admin_notification=schedule_admin_notification,
+    reward_service=reward_service,
 )
 
 mission_service.register_handlers(dp)
@@ -335,6 +345,7 @@ async def main() -> None:
         maintenance_service=maintenance_service,
         mission_service=mission_service,
         identity_service=identity_service,
+        reward_service=reward_service,
         profile_auto_sync_minutes=PROFILE_AUTO_SYNC_INTERVAL_MINUTES,
         logger=logger,
     )

--- a/bot_app/bootstrap.py
+++ b/bot_app/bootstrap.py
@@ -14,6 +14,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from services.db_manager import MongoManager
 from services.notification_service import EnhancedNotificationService
+from services.rewards_repository import RewardsRepository
 
 
 @dataclass(slots=True)
@@ -26,6 +27,7 @@ class BotAppContext:
     db_manager: MongoManager
     scheduler: AsyncIOScheduler
     mongo_client: motor.motor_asyncio.AsyncIOMotorClient
+    rewards_repository: RewardsRepository
 
 
 def _create_bot(token: str) -> Bot:
@@ -92,6 +94,7 @@ def create_app_context(
     bot = _create_bot(token)
     dispatcher = _create_dispatcher()
     mongo_client, db_manager = _create_mongo_manager(mongo_uri, database_name)
+    rewards_repository = RewardsRepository(db_manager=db_manager)
     notification_service = _create_notification_service(
         bot,
         admin_ids,
@@ -107,4 +110,5 @@ def create_app_context(
         db_manager=db_manager,
         scheduler=scheduler,
         mongo_client=mongo_client,
+        rewards_repository=rewards_repository,
     )

--- a/bot_app/scheduler.py
+++ b/bot_app/scheduler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
+from reward_service import RewardService
 from services.identity_service import IdentityService
 from services.maintenance_service import MaintenanceService
 from services.mission_service import MissionService
@@ -16,6 +17,7 @@ def setup_scheduler(
     maintenance_service: MaintenanceService,
     mission_service: MissionService,
     identity_service: IdentityService,
+    reward_service: RewardService,
     profile_auto_sync_minutes: int,
     logger,
 ) -> AsyncIOScheduler:
@@ -70,6 +72,24 @@ def setup_scheduler(
         "interval",
         hours=6,
         next_run_time=datetime.now(),
+    )
+
+    scheduler.add_job(
+        reward_service.publish_weekly_leaderboard,
+        "cron",
+        day_of_week="mon",
+        hour=9,
+        minute=0,
+        timezone="Europe/Rome",
+    )
+
+    scheduler.add_job(
+        reward_service.publish_monthly_leaderboard,
+        "cron",
+        day=1,
+        hour=9,
+        minute=5,
+        timezone="Europe/Rome",
     )
 
     if not scheduler.running:

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -6,6 +6,7 @@ from typing import Callable, Iterable, Sequence
 
 from aiogram import Bot, Dispatcher
 
+from reward_service import RewardService
 from services.db_manager import MongoManager
 from services.identity_service import IdentityService
 from services.mission_service import MissionService
@@ -18,6 +19,7 @@ from .member_search import MemberSearchHandlers
 from .menu import MenuHandlers
 from .missions import MissionHandlers
 from .profile_link import ProfileLinkHandlers
+from .rewards import RewardHandlers
 
 
 def register_user_flow_handlers(
@@ -35,6 +37,7 @@ def register_user_flow_handlers(
     admin_ids: Sequence[int],
     authorized_groups: Sequence[int],
     schedule_admin_notification: Callable[..., None],
+    reward_service: RewardService,
 ) -> None:
     """Instantiate feature routers and register them on the dispatcher."""
 
@@ -82,6 +85,11 @@ def register_user_flow_handlers(
         member_check_flow=member_handlers.start_member_question,
     )
 
+    reward_handlers = RewardHandlers(
+        reward_service=reward_service,
+        logger=logger,
+    )
+
     routers: Iterable = (
         create_admin_router(
             bot=bot,
@@ -96,6 +104,7 @@ def register_user_flow_handlers(
         member_handlers.router,
         profile_link_handlers.router,
         menu_handlers.router,
+        reward_handlers.router,
     )
 
     for router in routers:

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -24,6 +24,7 @@ class MenuHandlers:
         self.router = Router()
         self.router.message.register(self.start_command, Command("start"))
         self.router.message.register(self.menu_command, Command("menu"))
+        self.router.message.register(self.help_command, Command("help"))
         self.router.callback_query.register(
             self.handle_menu_callback, F.data.startswith("menu_")
         )
@@ -37,6 +38,9 @@ class MenuHandlers:
         keyboard = self._build_menu_keyboard()
         await message.answer("Scegli un'opzione:", reply_markup=keyboard)
         await self._delete_command_message(message)
+
+    async def help_command(self, message: types.Message) -> None:
+        await message.answer(self._help_text(), parse_mode="HTML")
 
     async def handle_menu_callback(
         self, callback: types.CallbackQuery, state: FSMContext
@@ -101,48 +105,57 @@ class MenuHandlers:
     def _help_text() -> str:
         return """<b>🤖 GUIDA COMPLETA BOT CLAN</b>
 
-<b>📋 FUNZIONI PRINCIPALI</b>
+<b>📌 NAVIGAZIONE RAPIDA</b>
+• <code>/start</code> – Avvia il bot e apre il menu principale interattivo
+• <code>/menu</code> – Richiama in qualsiasi momento le scorciatoie più utilizzate
+• <code>/help</code> – Elenco completo e sempre aggiornato delle funzionalità disponibili
 
-<b>👤 GIOCATORE</b>
-🔸 <i>Membro del Clan</i>: Visualizza lista paginata di tutti i membri
-🔸 <i>Ricerca Esterna</i>: Cerca qualsiasi giocatore per username
-🔸 <i>Profili Completi</i>: Statistiche, livello, clan, avatar
-🔸 <i>Avatar Gallery</i>: Visualizza tutti gli avatar del giocatore
+<b>🏆 SISTEMA RICOMPENSE</b>
+• <code>/classifica [periodo]</code> – Classifica dinamica dei punti premio (Top 10).<br>
+&nbsp;&nbsp;<i>Periodi supportati:</i> <code>totale</code>, <code>settimana</code>, <code>mese</code>, <code>oggi</code> e sinonimi.<br>
+&nbsp;&nbsp;<i>Dettagli inclusi:</i> punti del periodo, totale storico e icone degli achievement sbloccati.
+• <code>/progressi &lt;username&gt; [periodo]</code> – Scheda avanzata di un giocatore.<br>
+&nbsp;&nbsp;<i>Mostra:</i> punteggio complessivo, andamento nel periodo scelto, distribuzione per tipologia, ultimi eventi registrati e achievement ottenuti.
+• <i>Classifiche automatiche</i> – Aggiornamenti settimanali e mensili inviati in automatico agli amministratori via notifica.
+• <i>Notifiche achievement</i> – Ogni traguardo attiva un alert dedicato con riepilogo e bonus punti accreditati.
 
-<b>🏰 CLAN</b>
-🔸 <i>Clan Salvati</i>: Lista dei clan già cercati
-🔸 <i>Ricerca Diretta</i>: <code>/clan [ID]</code> per nuove ricerche
-🔸 <i>Info Complete</i>: Membri, risorse, statistiche clan
+<b>👤 GESTIONE GIOCATORI</b>
+• <i>Membro del Clan</i> – Elenco paginato con dati di profilo, stato online e attività recenti.
+• <i>Ricerca Esterna</i> – Trova qualsiasi giocatore partendo dallo username Wolvesville.
+• <i>Profili Completi</i> – Statistiche, livello, clan di appartenenza e galleria avatar sempre aggiornata.
+• <code>/collega</code> – Collega il profilo Telegram a quello di gioco per sbloccare funzioni avanzate e sincronizzazioni automatiche.
+
+<b>🏰 STRUMENTI CLAN</b>
+• <code>/clan [ID]</code> – Dossier completo su qualsiasi clan (membri, progressi, attività recenti).
+• <i>Clan salvati</i> – Accesso rapido alle ricerche più frequenti effettuate dal bot.
+• <i>Statistiche</i> – Analisi delle risorse condivise, andamento membri e confronto con i periodi precedenti.
 
 <b>⚔️ MISSIONI</b>
-🔸 <i>Skin Disponibili</i>: Visualizza missioni con anteprime
-🔸 <i>Skip Timer</i>: Salta tempo di attesa (solo admin)
-🔸 <i>Invio Automatico</i>: Ogni lunedì alle 11:00
+• <i>Skin disponibili</i> – Dettagli missione con immagini, costi e ricompense.
+• <i>Partecipanti</i> – Monitoraggio live dal menu «Player Missione».
+• <i>Skip timer</i> – Riduzione del tempo di attesa (riservata agli admin autorizzati).
+• <i>Supporto missioni</i> – Nuovo sistema premi per chi assiste le squadre durante i raid.
 
-<b>💰 BILANCIO DONAZIONI</b>
-🔸 <i>Calcolo Automatico</i>: Traccia donazioni e costi missioni
-🔸 <i>Visualizzazione</i>: Tabella ordinata di tutti i bilanci
-🔸 <i>Modifica Admin</i>: Solo amministratori possono modificare
-🔸 <i>Gestione Debiti</i>: Notifiche automatiche per uscite con debiti
+<b>💰 ECONOMIA</b>
+• <code>/balances</code> – Bilancio donazioni suddiviso per valuta e giocatore.
+• <i>Calcoli automatici</i> – Donazioni, costi missione e debiti gestiti in tempo reale.
+• <i>Ledger cronologico</i> – Storico contributi oro/gemme integrato con il sistema ricompense.
 
-<b>🎯 ABILITAZIONE MISSIONI</b>
-🔸 <i>Voti Automatici</i>: Abilita chi ha votato per una missione
-🔸 <i>Gestione Partecipanti</i>: Controllo completo dei partecipanti
-
-<b>🔧 FUNZIONI ADMIN</b>
-🔸 <i>Pulizia Database</i>: <code>/cleanup</code> - Rimuove duplicati
-🔸 <i>Controllo Uscite</i>: Monitora membri usciti dal clan
-🔸 <i>Gestione Automatica</i>: Sistema scheduler per manutenzione
+<b>🔧 COMANDI ADMIN</b>
+• <code>/cleanup</code> – Rimuove duplicati e sincronizza i dati tra le diverse collezioni MongoDB.
+• <i>Controllo uscite</i> – Notifiche automatiche per chi lascia il clan con debiti pendenti.
+• <i>Monitoraggio gruppi</i> – Alert immediati quando il bot entra in chat non autorizzate (con blacklist automatica).
 
 <b>🔄 AUTOMAZIONI</b>
-🔸 <i>Ledger Donazioni</i>: Aggiornamento ogni 5 minuti
-🔸 <i>Missioni Attive</i>: Calcolo costi ogni 5 minuti
-🔸 <i>Membri Clan</i>: Sincronizzazione ogni 3 giorni
-🔸 <i>Pulizia DB</i>: Rimozione duplicati ogni 24 ore
-🔸 <i>Controllo Uscite</i>: Verifica debiti ogni 6 ore
+• Ledger donazioni ogni 5 minuti
+• Calcolo missioni attive ogni 5 minuti
+• Sincronizzazione profili collegati ogni intervallo configurato
+• Pulizia database ogni 24 ore
+• Controllo uscite ogni 6 ore
+• Classifiche reward settimanali e mensili inviate automaticamente agli admin
 
 <b>💡 SUGGERIMENTI</b>
-• Usa <code>/start</code> o <code>/menu</code> per navigare
-• I comandi admin richiedono autorizzazione
-• Le modifiche ai bilanci sono tracciate automaticamente
-• Il bot mantiene cronologia delle ricerche clan"""
+• Usa il menu rapido per avviare i flussi guidati principali.
+• Specifica il periodo quando utilizzi <code>/classifica</code> o <code>/progressi</code> per filtrare i risultati.
+• Gli achievement sbloccati garantiscono punti bonus immediati registrati nello storico premi.
+• I comandi admin richiedono autorizzazioni dedicate: contatta il responsabile del clan per l'abilitazione."""

--- a/handlers/rewards.py
+++ b/handlers/rewards.py
@@ -1,0 +1,84 @@
+"""Gestione dei comandi relativi alle ricompense."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from aiogram import Router, types
+from aiogram.filters import Command, CommandObject
+
+from reward_service import RewardService
+
+
+@dataclass(slots=True)
+class RewardHandlers:
+    """Router dedicato a classifiche e progressi premi."""
+
+    reward_service: RewardService
+    logger: Any
+
+    def __post_init__(self) -> None:
+        self.router = Router()
+        self.router.message.register(self.leaderboard_command, Command("classifica"))
+        self.router.message.register(self.progress_command, Command("progressi"))
+
+    async def leaderboard_command(
+        self, message: types.Message, command: CommandObject
+    ) -> None:
+        period_arg: Optional[str] = None
+        if command.args:
+            period_arg = command.args.strip().split()[0]
+
+        period = self.reward_service.normalize_period(period_arg)
+        leaderboard = await self.reward_service.get_leaderboard(period=period, limit=10)
+        if not leaderboard:
+            await message.answer(
+                "Nessun dato disponibile per la classifica richiesta."
+            )
+            return
+
+        text = self.reward_service.build_leaderboard_message(
+            leaderboard,
+            period=period,
+            include_header=True,
+        )
+        await message.answer(text, parse_mode="Markdown")
+
+    async def progress_command(
+        self, message: types.Message, command: CommandObject
+    ) -> None:
+        username: Optional[str] = None
+        period_arg: Optional[str] = None
+
+        if command.args:
+            parts = command.args.split()
+            if parts:
+                username = parts[0]
+            if len(parts) > 1:
+                period_arg = parts[1]
+
+        if not username and message.from_user:
+            username = message.from_user.username
+
+        if not username:
+            await message.answer(
+                "Specifica uno username: /progressi <username> [periodo]"
+            )
+            return
+
+        username = username.strip()
+        if not username:
+            await message.answer(
+                "Specifica uno username: /progressi <username> [periodo]"
+            )
+            return
+
+        period = self.reward_service.normalize_period(period_arg)
+        progress = await self.reward_service.get_user_progress(username, period=period)
+        if not progress:
+            await message.answer(f"Nessun dato trovato per {username}.")
+            return
+
+        text = self.reward_service.build_progress_message(progress, period=period)
+        await message.answer(text, parse_mode="Markdown")

--- a/reward_service.py
+++ b/reward_service.py
@@ -1,149 +1,739 @@
-from datetime import datetime
-from typing import Dict, List, Optional
+"""Servizi di alto livello per la gestione delle ricompense del clan."""
 
-from services.db_manager import MongoManager
+from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+from zoneinfo import ZoneInfo
+
+from services.notification_service import EnhancedNotificationService, NotificationType
+from services.rewards_repository import RewardsRepository
+
+
+def _ensure_timezone(value: datetime) -> datetime:
+    """Garantisce che il datetime sia timezone-aware in UTC."""
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(slots=True)
 class RewardService:
-    def __init__(self, db_manager: MongoManager):
-        self.db = db_manager
-        
-        # Configurazione punti
-        self.POINTS_CONFIG = {
-            "DONATION_ORO": 1,      # 1 punto per 1000 oro
-            "DONATION_GEM": 2,      # 2 punti per 1000 gem  
-            "MISSION_PARTICIPATION": 5,
-            "WEEKLY_BONUS": 10,
-            "MONTHLY_BONUS": 50
-        }
-        
-        # Achievement definitions
-        self.ACHIEVEMENTS = {
-            "FIRST_DONATION": {"points": 10, "name": "Prima Donazione", "icon": "🎯"},
-            "BIG_DONOR": {"points": 25, "name": "Grande Donatore", "icon": "💎"},
-            "MISSION_VETERAN": {"points": 30, "name": "Veterano Missioni", "icon": "⚔️"},
-            "CLAN_LEGEND": {"points": 100, "name": "Leggenda del Clan", "icon": "👑"}
-        }
-        
-    async def award_points(
-        self, username: str, point_type: str, amount: Optional[int] = None
-    ) -> int:
-        """Assegna punti a un utente"""
-        safe_amount = max(amount or 0, 0)
+    """Coordinatore dell'intero ecosistema reward."""
 
-        canonical_username = (username or "").strip()
-        if not canonical_username:
+    repository: RewardsRepository
+    notification_service: Optional[EnhancedNotificationService] = None
+    logger: Any = None
+
+    def __post_init__(self) -> None:
+        self.logger = self.logger or logging.getLogger(__name__)
+        self._local_tz = ZoneInfo("Europe/Rome")
+
+        self.POINTS_CONFIG: Dict[str, Dict[str, Any]] = {
+            "DONATION_ORO": {
+                "mode": "donation",
+                "per_amount": 1000,
+                "multiplier": 1,
+                "min_points": 1,
+                "label": "Donazioni Oro",
+            },
+            "DONATION_GEM": {
+                "mode": "donation",
+                "per_amount": 1000,
+                "multiplier": 2,
+                "min_points": 2,
+                "label": "Donazioni Gem",
+            },
+            "MISSION_PARTICIPATION": {
+                "mode": "fixed",
+                "points": 5,
+                "label": "Partecipazione Missione",
+            },
+            "MISSION_SUCCESS": {
+                "mode": "fixed",
+                "points": 8,
+                "label": "Missione Completata",
+            },
+            "MISSION_SUPPORT": {
+                "mode": "ratio",
+                "ratio": 0.5,
+                "label": "Supporto Missione",
+            },
+            "WEEKLY_BONUS": {
+                "mode": "fixed",
+                "points": 10,
+                "label": "Bonus Settimanale",
+            },
+            "MONTHLY_BONUS": {
+                "mode": "fixed",
+                "points": 50,
+                "label": "Bonus Mensile",
+            },
+            "EVENT_BONUS": {
+                "mode": "fixed",
+                "points": 20,
+                "label": "Evento Speciale",
+            },
+            "TRAINING_ATTENDANCE": {
+                "mode": "fixed",
+                "points": 3,
+                "label": "Allenamento",
+            },
+            "RAID_VICTORY": {
+                "mode": "fixed",
+                "points": 25,
+                "label": "Vittoria Raid",
+            },
+            "DAILY_LOGIN": {
+                "mode": "fixed",
+                "points": 1,
+                "label": "Accesso Giornaliero",
+            },
+            "ACHIEVEMENT_BONUS": {
+                "mode": "fixed",
+                "points": 0,
+                "label": "Bonus Achievement",
+            },
+            "PENALTY": {
+                "mode": "fixed",
+                "points": -5,
+                "allow_negative": True,
+                "label": "Penalità",
+            },
+        }
+
+        self.POINT_TYPE_ALIASES: Dict[str, str] = {
+            "oro": "DONATION_ORO",
+            "gold": "DONATION_ORO",
+            "donation_oro": "DONATION_ORO",
+            "gem": "DONATION_GEM",
+            "gems": "DONATION_GEM",
+            "gemme": "DONATION_GEM",
+            "donation_gem": "DONATION_GEM",
+            "support": "MISSION_SUPPORT",
+            "mission_support": "MISSION_SUPPORT",
+            "training": "TRAINING_ATTENDANCE",
+            "allenamento": "TRAINING_ATTENDANCE",
+            "raid": "RAID_VICTORY",
+            "raid_victory": "RAID_VICTORY",
+            "daily": "DAILY_LOGIN",
+            "login": "DAILY_LOGIN",
+        }
+
+        self._period_aliases: Dict[str, Dict[str, Any]] = {
+            "all": {"aliases": {"", "all", "totale", "sempre", "overall"}, "label": "generale"},
+            "weekly": {
+                "aliases": {"week", "weekly", "settimana", "settimanale"},
+                "label": "settimanale",
+            },
+            "monthly": {
+                "aliases": {"month", "monthly", "mese", "mensile"},
+                "label": "mensile",
+            },
+            "daily": {
+                "aliases": {"day", "daily", "oggi", "giorno", "giornaliera"},
+                "label": "giornaliera",
+            },
+        }
+
+        self.ACHIEVEMENTS: Dict[str, Dict[str, Any]] = {
+            "FIRST_DONATION": {
+                "points_bonus": 10,
+                "name": "Prima Donazione",
+                "icon": "🎯",
+                "description": "Effettua la tua prima donazione in oro o gemme.",
+                "criteria": {
+                    "any": [
+                        {"metric": "donations.Oro", "gte": 1},
+                        {"metric": "donations.Gem", "gte": 1},
+                        {"metric": "history.by_type.DONATION_ORO.events", "gte": 1},
+                        {"metric": "history.by_type.DONATION_GEM.events", "gte": 1},
+                    ]
+                },
+            },
+            "BIG_DONOR": {
+                "points_bonus": 25,
+                "name": "Grande Donatore",
+                "icon": "💎",
+                "description": "Raggiungi 50k oro o 20k gemme donate complessivamente.",
+                "criteria": {
+                    "any": [
+                        {"metric": "donations.Oro", "gte": 50000},
+                        {"metric": "donations.Gem", "gte": 20000},
+                    ]
+                },
+            },
+            "MISSION_VETERAN": {
+                "points_bonus": 30,
+                "name": "Veterano Missioni",
+                "icon": "⚔️",
+                "description": "Partecipa ad almeno 10 missioni monitorate.",
+                "criteria": {
+                    "metric": "history.by_type.MISSION_PARTICIPATION.events",
+                    "gte": 10,
+                },
+            },
+            "CLAN_LEGEND": {
+                "points_bonus": 50,
+                "name": "Leggenda del Clan",
+                "icon": "👑",
+                "description": "Supera i 1000 punti ricompensa totali.",
+                "criteria": {"metric": "reward_points", "gte": 1000},
+            },
+            "SUPPORT_SPECIALIST": {
+                "points_bonus": 15,
+                "name": "Specialista di Supporto",
+                "icon": "🛡️",
+                "description": "Accumula punti assistendo le missioni degli alleati.",
+                "criteria": {
+                    "any": [
+                        {
+                            "metric": "history.by_type.MISSION_SUPPORT.events",
+                            "gte": 5,
+                        },
+                        {
+                            "metric": "history.by_type.MISSION_SUPPORT.points",
+                            "gte": 25,
+                        },
+                    ]
+                },
+            },
+            "DAILY_GRINDER": {
+                "points_bonus": 10,
+                "name": "Costanza Quotidiana",
+                "icon": "🗓️",
+                "description": "Raccogli premi partecipando ogni giorno alle attività del clan.",
+                "criteria": {
+                    "metric": "history.by_type.DAILY_LOGIN.events",
+                    "gte": 7,
+                },
+            },
+            "RESOURCE_TYCOON": {
+                "points_bonus": 40,
+                "name": "Magnate delle Risorse",
+                "icon": "🏦",
+                "description": "Supera gli obiettivi di donazioni oro e gemme nel lungo periodo.",
+                "criteria": {
+                    "all": [
+                        {
+                            "metric": "history.by_type.DONATION_ORO.total_amount",
+                            "gte": 100000,
+                        },
+                        {
+                            "metric": "history.by_type.DONATION_GEM.total_amount",
+                            "gte": 5000,
+                        },
+                    ]
+                },
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Normalizzazioni e helper
+    # ------------------------------------------------------------------
+    def normalize_period(self, period: Optional[str]) -> str:
+        normalized = (period or "").strip().lower()
+        for canonical, info in self._period_aliases.items():
+            if normalized in info["aliases"]:
+                return canonical
+        return "all"
+
+    def _period_label(self, period: str) -> str:
+        info = self._period_aliases.get(period, self._period_aliases["all"])
+        return info.get("label", period)
+
+    def _normalize_point_type(self, point_type: str) -> Optional[str]:
+        if not point_type:
+            return None
+        normalized = point_type.strip().upper()
+        if normalized in self.POINTS_CONFIG:
+            return normalized
+        alias = self.POINT_TYPE_ALIASES.get(normalized.lower())
+        return alias
+
+    def _normalize_amount(self, amount: Any, *, allow_negative: bool = False) -> int:
+        if amount is None:
             return 0
 
-        try:
-            resolution = await self.db.resolve_profile_by_game_alias(canonical_username)
-        except Exception:
-            resolution = None
-
-        if resolution and resolution.get("resolved_username"):
-            canonical_username = resolution.get("resolved_username")
-
-        if point_type == "DONATION_ORO":
-            base_units = safe_amount // 1000
-            if safe_amount > 0:
-                base_units = max(1, base_units)
-            points = base_units * self.POINTS_CONFIG["DONATION_ORO"]
-        elif point_type == "DONATION_GEM":
-            base_units = safe_amount // 1000
-            if safe_amount > 0:
-                base_units = max(1, base_units)
-            points = base_units * self.POINTS_CONFIG["DONATION_GEM"]
+        numeric: float
+        if isinstance(amount, (int, float)):
+            numeric = float(amount)
         else:
-            points = self.POINTS_CONFIG.get(point_type, 0)
-
-        if points <= 0:
-            return 0
-
-        # Aggiorna database
-        await self.db.increment_reward_points(canonical_username, points)
-
-        # Controlla achievement
-        await self.check_achievements(canonical_username)
-
-        return points
-        
-    async def check_achievements(self, username: str):
-        """Controlla se l'utente ha sbloccato achievement"""
-        target_username = (username or "").strip()
-        if not target_username:
-            return []
-
-        user_data = await self.db.fetch_user(target_username)
-        if not user_data:
             try:
-                resolution = await self.db.resolve_profile_by_game_alias(target_username)
+                raw_text = str(amount).strip().lower()
             except Exception:
-                resolution = None
-            if resolution and resolution.get("resolved_username"):
-                target_username = resolution.get("resolved_username")
-                user_data = await self.db.fetch_user(target_username)
-        if not user_data:
-            return []
+                return 0
 
-        donazioni = user_data.get("donazioni", {})
-        total_oro = donazioni.get("Oro", 0)
-        total_gem = donazioni.get("Gem", 0)
-        current_achievements = user_data.get("achievements", [])
-        await self.db.increment_reward_points(username, points)
+            if not raw_text:
+                return 0
 
-        # Controlla achievement
-        await self.check_achievements(username)
+            multiplier = 1.0
+            if raw_text.endswith(("k", "m")):
+                suffix = raw_text[-1]
+                raw_text = raw_text[:-1].strip()
+                if suffix == "k":
+                    multiplier = 1000.0
+                elif suffix == "m":
+                    multiplier = 1_000_000.0
 
+            # Rimuove separatori migliaia comuni e normalizza la parte decimale.
+            sanitized = raw_text.replace("'", "").replace("_", "").replace(" ", "")
+            if "," in sanitized and "." in sanitized:
+                if sanitized.rfind(",") > sanitized.rfind("."):
+                    sanitized = sanitized.replace(".", "").replace(",", ".")
+                else:
+                    sanitized = sanitized.replace(",", "")
+            elif sanitized.count(".") > 1 and "," not in sanitized:
+                sanitized = sanitized.replace(".", "")
+            elif sanitized.count(",") > 1 and "." not in sanitized:
+                sanitized = sanitized.replace(",", "")
+            else:
+                sanitized = sanitized.replace(",", ".")
+
+            try:
+                numeric = float(sanitized) * multiplier
+            except (TypeError, ValueError):
+                return 0
+
+        if not allow_negative:
+            numeric = max(numeric, 0.0)
+
+        return int(round(numeric))
+
+    def _compute_points(self, config: Dict[str, Any], amount: int) -> int:
+        mode = config.get("mode", "fixed")
+
+        if mode == "donation":
+            if amount <= 0:
+                return 0
+            per_amount = max(int(config.get("per_amount", 1000)), 1)
+            multiplier = int(config.get("multiplier", 1))
+            min_points = int(config.get("min_points", 0))
+            units = amount // per_amount
+            computed = units * multiplier
+            if computed <= 0 and min_points > 0:
+                computed = min_points
+            elif min_points > 0:
+                computed = max(computed, min_points)
+            return int(computed)
+
+        if mode == "ratio":
+            ratio = float(config.get("ratio", 1.0))
+            value = amount * ratio
+            return int(round(value))
+
+        points = int(config.get("points", 0))
+        if config.get("allow_override") and amount:
+            points = int(amount)
         return points
-        
-    async def check_achievements(self, username: str):
-        """Controlla se l'utente ha sbloccato achievement"""
-        user_data = await self.db.fetch_user(username)
-        if not user_data:
+
+    def _format_points(self, value: int) -> str:
+        return f"{int(value):,}".replace(",", ".")
+
+    def _point_type_label(self, point_type: str) -> str:
+        config = self.POINTS_CONFIG.get(point_type, {})
+        return config.get("label", point_type.replace("_", " ").title())
+
+    def _achievement_icons(self, achievements: Sequence[str]) -> str:
+        icons = [self.ACHIEVEMENTS.get(code, {}).get("icon", "") for code in achievements]
+        return "".join(icon for icon in icons if icon)
+
+    def _format_timestamp(self, value: Any) -> str:
+        if not isinstance(value, datetime):
+            return ""
+        aware = _ensure_timezone(value)
+        local = aware.astimezone(self._local_tz)
+        return local.strftime("%d/%m %H:%M")
+
+    async def _build_metrics(self, username: str, user_snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        donations_raw = user_snapshot.get("donazioni", {}) or {}
+        donations = {
+            key: int(value or 0)
+            for key, value in donations_raw.items()
+            if isinstance(key, str)
+        }
+
+        history_stats = await self.repository.get_user_point_breakdown(username)
+
+        return {
+            "reward_points": int(user_snapshot.get("reward_points", 0) or 0),
+            "donations": donations,
+            "history": history_stats,
+            "achievements": set(user_snapshot.get("achievements", []) or []),
+        }
+
+    def _extract_metric(self, metrics: Dict[str, Any], path: str) -> Any:
+        if not path:
+            return None
+        parts = path.split(".")
+        current: Any = metrics
+        for part in parts:
+            if isinstance(current, dict):
+                current = current.get(part)
+            else:
+                return None
+        return current
+
+    def _evaluate_criteria(self, criteria: Dict[str, Any], metrics: Dict[str, Any]) -> bool:
+        if not criteria:
+            return False
+
+        if "all" in criteria:
+            return all(self._evaluate_criteria(item, metrics) for item in criteria["all"])
+        if "any" in criteria:
+            return any(self._evaluate_criteria(item, metrics) for item in criteria["any"])
+
+        metric_path = criteria.get("metric")
+        value = self._extract_metric(metrics, metric_path)
+
+        if value is None:
+            return False
+
+        if "in" in criteria:
+            expected = set(criteria["in"])
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                return bool(expected.intersection(value))
+            return value in expected
+
+        comparisons = {
+            "gte": lambda a, b: a >= b,
+            "gt": lambda a, b: a > b,
+            "lte": lambda a, b: a <= b,
+            "lt": lambda a, b: a < b,
+            "eq": lambda a, b: a == b,
+        }
+
+        numeric_value: Optional[float]
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            numeric_value = None
+
+        for operator, comparator in comparisons.items():
+            if operator in criteria and numeric_value is not None:
+                return comparator(numeric_value, float(criteria[operator]))
+
+        return bool(value)
+
+    # ------------------------------------------------------------------
+    # API pubbliche
+    # ------------------------------------------------------------------
+    async def award_points(
+        self,
+        username: str,
+        point_type: str,
+        *,
+        amount: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        canonical_point_type = self._normalize_point_type(point_type)
+        if not canonical_point_type:
+            self.logger.warning("Tipologia punti sconosciuta: %s", point_type)
+            return {"awarded_points": 0, "total_points": None}
+
+        canonical_username = await self.repository.resolve_username(username)
+        if not canonical_username:
+            self.logger.warning("Impossibile normalizzare username per award_points: %s", username)
+            return {"awarded_points": 0, "total_points": None}
+
+        config = self.POINTS_CONFIG[canonical_point_type]
+        normalized_amount = self._normalize_amount(
+            amount,
+            allow_negative=config.get("allow_negative", False),
+        )
+        points = self._compute_points(config, normalized_amount)
+
+        if points == 0:
+            return {
+                "username": canonical_username,
+                "awarded_points": 0,
+                "total_points": None,
+            }
+
+        increment_result = await self.repository.increment_points(
+            canonical_username,
+            points,
+            point_type=canonical_point_type,
+            amount=normalized_amount,
+            metadata=metadata or {},
+        )
+
+        user_snapshot = await self.repository.get_user(canonical_username) or {}
+        new_achievements = await self.check_achievements(canonical_username, user_snapshot=user_snapshot)
+
+        return {
+            "username": canonical_username,
+            "awarded_points": points,
+            "total_points": increment_result.get("new_total"),
+            "point_type": canonical_point_type,
+            "normalized_amount": normalized_amount,
+            "new_achievements": new_achievements,
+        }
+
+    async def check_achievements(
+        self,
+        username: str,
+        *,
+        user_snapshot: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        if not username:
             return []
-            
-        donazioni = user_data.get("donazioni", {})
-        total_oro = donazioni.get("Oro", 0)
-        total_gem = donazioni.get("Gem", 0)
-        current_achievements = user_data.get("achievements", [])
-        
-        new_achievements = []
-        
-        # Prima donazione
-        if "FIRST_DONATION" not in current_achievements and (total_oro > 0 or total_gem > 0):
-            new_achievements.append("FIRST_DONATION")
-            
-        # Grande donatore (50k oro o 20k gem)
-        if "BIG_DONOR" not in current_achievements and (total_oro >= 50000 or total_gem >= 20000):
-            new_achievements.append("BIG_DONOR")
-            
-        # Aggiorna database con nuovi achievement
-        if new_achievements:
-            await self.db.add_achievements(target_username, new_achievements)
-            await self.db.add_achievements(username, new_achievements)
 
-        return new_achievements
-        
-    async def get_leaderboard(self, limit: int = 10) -> List[Dict]:
-        """Genera leaderboard punti"""
-        pipeline = [
-            {"$match": {"reward_points": {"$gt": 0}}},
-            {"$sort": {"reward_points": -1}},
-            {"$limit": limit}
-        ]
+        snapshot = user_snapshot or await self.repository.get_user(username)
+        if not snapshot:
+            return []
 
-        leaderboard = await self.db.aggregate_users(pipeline)
-        return leaderboard
+        metrics = await self._build_metrics(username, snapshot)
+        unlocked: List[Dict[str, Any]] = []
+        current = metrics.get("achievements", set())
 
-    async def get_top_contributors(
+        for code, definition in self.ACHIEVEMENTS.items():
+            if code in current:
+                continue
+            if self._evaluate_criteria(definition.get("criteria", {}), metrics):
+                appended = await self.repository.append_achievement(
+                    username,
+                    code,
+                    {
+                        "name": definition.get("name"),
+                        "icon": definition.get("icon"),
+                        "description": definition.get("description"),
+                    },
+                )
+                if not appended:
+                    continue
+
+                current.add(code)
+                unlocked.append(
+                    {
+                        "code": code,
+                        "name": definition.get("name"),
+                        "icon": definition.get("icon"),
+                        "points_bonus": definition.get("points_bonus", 0),
+                    }
+                )
+
+                bonus = int(definition.get("points_bonus", 0) or 0)
+                if bonus:
+                    await self.repository.increment_points(
+                        username,
+                        bonus,
+                        point_type="ACHIEVEMENT_BONUS",
+                        amount=0,
+                        metadata={"achievement": code},
+                    )
+
+        if unlocked and self.notification_service:
+            try:
+                message_lines = [
+                    f"🏅 Nuovi achievement per *{username}*:",
+                    "",
+                ]
+                for achievement in unlocked:
+                    icon = achievement.get("icon", "🏅")
+                    name = achievement.get("name", achievement.get("code"))
+                    bonus = achievement.get("points_bonus", 0)
+                    if bonus:
+                        message_lines.append(f"{icon} {name} (+{bonus} pt)")
+                    else:
+                        message_lines.append(f"{icon} {name}")
+                message = "\n".join(message_lines)
+                await self.notification_service.send_admin_notification(
+                    message,
+                    notification_type=NotificationType.SUCCESS,
+                    disable_rate_limit=True,
+                )
+            except Exception as exc:  # pragma: no cover - log difensivo
+                self.logger.warning("Invio notifica achievement fallito: %s", exc)
+
+        return unlocked
+
+    async def get_leaderboard(
         self,
         *,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
         limit: int = 10,
-        currency: Optional[str] = None,
-    ) -> List[Dict]:
-        """Espone i donatori principali per la logica premi."""
-
-        return await self.db.get_top_donors(
-            limit=limit, start=start, end=end, currency=currency
+        period: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        normalized_period = self.normalize_period(period)
+        period_start = self.repository.compute_period_start(normalized_period)
+        leaderboard = await self.repository.get_leaderboard(
+            limit=limit,
+            period_start=period_start,
         )
+        return leaderboard
+
+    async def get_user_progress(
+        self,
+        username: str,
+        *,
+        period: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        normalized_period = self.normalize_period(period)
+        period_start = self.repository.compute_period_start(normalized_period)
+        return await self.repository.get_user_progress(
+            username,
+            period_start=period_start,
+        )
+
+    def build_leaderboard_message(
+        self,
+        entries: Sequence[Dict[str, Any]],
+        *,
+        period: str,
+        include_header: bool = True,
+    ) -> str:
+        if not entries:
+            return "Nessun dato disponibile per la classifica richiesta."
+
+        lines: List[str] = []
+        label = self._period_label(period)
+        if include_header:
+            lines.extend([f"🏆 *Classifica {label}*", ""])
+
+        for index, entry in enumerate(entries, start=1):
+            username = entry.get("username", "Sconosciuto")
+            period_points = int(entry.get("period_points", 0) or 0)
+            total_points = int(entry.get("total_points", period_points) or 0)
+            icons = self._achievement_icons(entry.get("achievements", []))
+            if period == "all":
+                lines.append(
+                    f"{index}. *{username}* — {self._format_points(total_points)} pt {icons}".rstrip()
+                )
+            else:
+                lines.append(
+                    (
+                        f"{index}. *{username}* — {self._format_points(period_points)} pt"
+                        f" ({self._format_points(total_points)} tot.) {icons}"
+                    ).rstrip()
+                )
+
+        return "\n".join(lines).strip()
+
+    def build_progress_message(
+        self,
+        progress: Dict[str, Any],
+        *,
+        period: str,
+    ) -> str:
+        if not progress:
+            return "Nessuna informazione sui progressi disponibile."
+
+        username = progress.get("username", "Sconosciuto")
+        lines = [f"📈 *Progressi di {username}*", ""]
+
+        total_points = int(progress.get("total_points", 0) or 0)
+        lines.append(f"• Punti totali: {self._format_points(total_points)} pt")
+
+        period_points = progress.get("period_points")
+        if period_points is not None and period != "all":
+            label = self._period_label(period)
+            lines.append(
+                f"• Punti {label}: {self._format_points(int(period_points))} pt"
+            )
+
+        breakdown = progress.get("breakdown", {}).get("by_type", {})
+        if breakdown:
+            lines.append("• Distribuzione punti:")
+            for point_type, data in sorted(
+                breakdown.items(),
+                key=lambda item: int(item[1].get("points", 0)),
+                reverse=True,
+            ):
+                label = self._point_type_label(point_type)
+                points_value = self._format_points(int(data.get("points", 0) or 0))
+                events = int(data.get("events", 0) or 0)
+                amount_value = data.get("total_amount")
+                amount_text = ""
+                if amount_value is not None:
+                    try:
+                        amount_int = int(round(float(amount_value)))
+                    except (TypeError, ValueError):
+                        amount_int = None
+                    if amount_int:
+                        amount_text = f" (valore {self._format_points(amount_int)})"
+
+                lines.append(
+                    f"   ◦ {label}: {points_value} pt in {events} eventi{amount_text}"
+                )
+
+        achievements = progress.get("achievements") or []
+        if achievements:
+            lines.append("• Achievement sbloccati:")
+            for code in achievements:
+                info = self.ACHIEVEMENTS.get(code)
+                if info:
+                    lines.append(f"   ◦ {info.get('icon', '🏅')} {info.get('name')}")
+                else:
+                    lines.append(f"   ◦ {code}")
+
+        history: Sequence[Dict[str, Any]] = progress.get("history") or []
+        if history:
+            lines.append("• Ultimi eventi registrati:")
+            for event in history[:5]:
+                timestamp = self._format_timestamp(event.get("created_at"))
+                if event.get("event_type") == "achievement":
+                    achievement = event.get("achievement", {})
+                    icon = achievement.get("icon", "🏅")
+                    name = achievement.get("name", achievement.get("code", "Achievement"))
+                    lines.append(f"   ◦ {timestamp} — {icon} {name}")
+                else:
+                    delta = int(event.get("points", 0) or 0)
+                    prefix = "+" if delta > 0 else ""
+                    label = self._point_type_label(event.get("point_type", ""))
+                    amount_raw = event.get("amount")
+                    amount_text = ""
+                    if amount_raw is not None:
+                        try:
+                            amount_int = int(round(float(amount_raw)))
+                        except (TypeError, ValueError):
+                            amount_int = None
+                        if amount_int:
+                            amount_text = (
+                                f" — valore {self._format_points(amount_int)}"
+                            )
+
+                    lines.append(
+                        f"   ◦ {timestamp} — {prefix}{delta} pt ({label}){amount_text}"
+                    )
+
+        return "\n".join(lines).strip()
+
+    async def publish_periodic_leaderboard(
+        self,
+        period: str,
+        *,
+        limit: int = 10,
+    ) -> None:
+        if not self.notification_service:
+            return
+
+        normalized_period = self.normalize_period(period)
+        entries = await self.get_leaderboard(limit=limit, period=normalized_period)
+        if not entries:
+            return
+
+        body = self.build_leaderboard_message(
+            entries,
+            period=normalized_period,
+            include_header=False,
+        )
+        header = f"📊 Aggiornamento classifica {self._period_label(normalized_period)}"
+        message = f"{header}\n\n{body}".strip()
+
+        try:
+            await self.notification_service.send_admin_notification(
+                message,
+                notification_type=NotificationType.INFO,
+                disable_rate_limit=True,
+            )
+        except Exception as exc:  # pragma: no cover - log difensivo
+            self.logger.warning("Invio classifica periodica fallito: %s", exc)
+
+    async def publish_weekly_leaderboard(self) -> None:
+        await self.publish_periodic_leaderboard("weekly")
+
+    async def publish_monthly_leaderboard(self) -> None:
+        await self.publish_periodic_leaderboard("monthly")

--- a/services/db_manager.py
+++ b/services/db_manager.py
@@ -29,6 +29,7 @@ class MongoManager:
         self.donation_history_col: AsyncIOMotorCollection = self._database["donation_history"]
         self.missions_history_col: AsyncIOMotorCollection = self._database["missions_history"]
         self.player_profiles_col: AsyncIOMotorCollection = self._database["player_profiles"]
+        self.rewards_history_col: AsyncIOMotorCollection = self._database["rewards_history"]
 
     @property
     def database(self) -> AsyncIOMotorDatabase:

--- a/services/rewards_repository.py
+++ b/services/rewards_repository.py
@@ -1,0 +1,354 @@
+"""Repository dedicato alla gestione dei punti ricompensa."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from motor.motor_asyncio import AsyncIOMotorCollection
+from pymongo import ReturnDocument
+
+from services.db_manager import MongoManager
+
+
+def _ensure_timezone(value: datetime) -> datetime:
+    """Rende timezone aware i datetime salvati in cronologia."""
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(slots=True)
+class RewardsRepository:
+    """Incapsula l'accesso ai dati per il sistema premi."""
+
+    db_manager: MongoManager
+    _users: AsyncIOMotorCollection = field(init=False, repr=False)
+    _history: AsyncIOMotorCollection = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._users: AsyncIOMotorCollection = self.db_manager.users_col
+        self._history: AsyncIOMotorCollection = self.db_manager.rewards_history_col
+
+    # ------------------------------------------------------------------
+    # Operazioni di scrittura
+    # ------------------------------------------------------------------
+    async def increment_points(
+        self,
+        username: str,
+        points: int,
+        *,
+        point_type: str,
+        amount: Optional[int] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Incrementa i punti di un utente e registra l'evento in cronologia."""
+
+        if not username or points == 0:
+            return {"acknowledged": False, "new_total": None}
+
+        now = datetime.now(timezone.utc)
+        document = await self._users.find_one_and_update(
+            {"username": username},
+            {
+                "$inc": {"reward_points": points},
+                "$setOnInsert": {"username": username, "reward_points": 0},
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+
+        running_total = int(document.get("reward_points", 0)) if document else points
+
+        history_payload: Dict[str, Any] = {
+            "username": username,
+            "event_type": "points",
+            "point_type": point_type,
+            "points": points,
+            "amount": amount,
+            "metadata": metadata or {},
+            "running_total": running_total,
+            "created_at": now,
+        }
+
+        await self._history.insert_one(history_payload)
+
+        return {
+            "acknowledged": True,
+            "new_total": running_total,
+            "history_event": history_payload,
+        }
+
+    async def append_achievement(
+        self,
+        username: str,
+        achievement_code: str,
+        details: Dict[str, Any],
+    ) -> bool:
+        """Memorizza un nuovo achievement e lo aggiunge alla cronologia."""
+
+        if not username or not achievement_code:
+            return False
+
+        existing = await self._users.find_one({"username": username})
+        if existing and achievement_code in (existing.get("achievements") or []):
+            return False
+
+        update_result = await self._users.find_one_and_update(
+            {"username": username},
+            {
+                "$addToSet": {"achievements": achievement_code},
+                "$setOnInsert": {"username": username, "reward_points": 0},
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+
+        if not update_result:
+            return False
+
+        achievements: Sequence[str] = update_result.get("achievements", []) or []
+        if achievement_code not in achievements:
+            return False
+
+        running_total = int(update_result.get("reward_points", 0) or 0)
+        payload = {
+            "username": username,
+            "event_type": "achievement",
+            "achievement": {
+                "code": achievement_code,
+                **details,
+            },
+            "points": 0,
+            "running_total": running_total,
+            "created_at": datetime.now(timezone.utc),
+        }
+
+        await self._history.insert_one(payload)
+        return True
+
+    # ------------------------------------------------------------------
+    # Operazioni di lettura
+    # ------------------------------------------------------------------
+    async def get_user(self, username: str) -> Optional[Dict[str, Any]]:
+        """Recupera il documento utente completo."""
+
+        if not username:
+            return None
+        return await self._users.find_one({"username": username})
+
+    async def resolve_username(self, username: str) -> Optional[str]:
+        """Risolvi eventuali alias utilizzando l'Identity Service."""
+
+        if not username:
+            return None
+
+        normalized = username.strip()
+        if not normalized:
+            return None
+
+        resolution = await self.db_manager.resolve_profile_by_game_alias(normalized)
+        if resolution and resolution.get("resolved_username"):
+            return resolution["resolved_username"]
+        return normalized
+
+    async def get_user_point_breakdown(self, username: str) -> Dict[str, Any]:
+        """Restituisce la suddivisione dei punti per tipologia."""
+
+        if not username:
+            return {"total_events": 0, "total_points": 0, "by_type": {}}
+
+        pipeline = [
+            {"$match": {"username": username, "event_type": "points"}},
+            {
+                "$group": {
+                    "_id": "$point_type",
+                    "points": {"$sum": "$points"},
+                    "events": {"$sum": 1},
+                    "total_amount": {"$sum": {"$ifNull": ["$amount", 0]}},
+                    "last_event": {"$max": "$created_at"},
+                }
+            },
+        ]
+
+        entries = await self._history.aggregate(pipeline).to_list(length=None)
+        by_type: Dict[str, Any] = {}
+        total_points = 0
+        total_events = 0
+
+        for entry in entries:
+            point_type = entry.get("_id")
+            if not point_type:
+                continue
+            points_value = int(entry.get("points", 0) or 0)
+            events_value = int(entry.get("events", 0) or 0)
+            total_points += points_value
+            total_events += events_value
+            by_type[point_type] = {
+                "points": points_value,
+                "events": events_value,
+                "total_amount": entry.get("total_amount", 0),
+                "last_event": entry.get("last_event"),
+            }
+
+        return {
+            "total_points": total_points,
+            "total_events": total_events,
+            "by_type": by_type,
+        }
+
+    async def get_leaderboard(
+        self,
+        *,
+        limit: int = 10,
+        period_start: Optional[datetime] = None,
+    ) -> List[Dict[str, Any]]:
+        """Restituisce la classifica in base all'intervallo richiesto."""
+
+        limit = max(int(limit), 1)
+
+        if period_start is None:
+            cursor = (
+                self._users.find({"reward_points": {"$gt": 0}})
+                .sort("reward_points", -1)
+                .limit(limit)
+            )
+            users = await cursor.to_list(length=None)
+            return [
+                {
+                    "username": doc.get("username"),
+                    "total_points": int(doc.get("reward_points", 0) or 0),
+                    "period_points": int(doc.get("reward_points", 0) or 0),
+                    "achievements": doc.get("achievements", []),
+                }
+                for doc in users
+                if doc.get("username")
+            ]
+
+        match_stage: Dict[str, Any] = {
+            "username": {"$ne": None},
+            "event_type": "points",
+            "created_at": {"$gte": _ensure_timezone(period_start)},
+        }
+
+        pipeline = [
+            {"$match": match_stage},
+            {
+                "$group": {
+                    "_id": "$username",
+                    "period_points": {"$sum": "$points"},
+                    "last_event": {"$max": "$created_at"},
+                }
+            },
+            {"$sort": {"period_points": -1, "last_event": 1}},
+            {"$limit": limit},
+        ]
+
+        leaderboard = await self._history.aggregate(pipeline).to_list(length=None)
+        usernames = [entry.get("_id") for entry in leaderboard if entry.get("_id")]
+
+        if not usernames:
+            return []
+
+        user_docs = await self._users.find({"username": {"$in": usernames}}).to_list(length=None)
+        user_map = {doc.get("username"): doc for doc in user_docs}
+
+        enriched: List[Dict[str, Any]] = []
+        for entry in leaderboard:
+            username = entry.get("_id")
+            if not username:
+                continue
+            user_doc = user_map.get(username, {})
+            enriched.append(
+                {
+                    "username": username,
+                    "period_points": int(entry.get("period_points", 0) or 0),
+                    "total_points": int(user_doc.get("reward_points", 0) or 0),
+                    "achievements": user_doc.get("achievements", []),
+                    "last_event": entry.get("last_event"),
+                }
+            )
+
+        return enriched
+
+    async def get_user_progress(
+        self,
+        username: str,
+        *,
+        period_start: Optional[datetime] = None,
+        history_limit: int = 5,
+    ) -> Optional[Dict[str, Any]]:
+        """Recupera un riepilogo dei progressi dell'utente."""
+
+        if not username:
+            return None
+
+        user_doc = await self.get_user(username)
+        if not user_doc:
+            return None
+
+        history_cursor = (
+            self._history.find({"username": username})
+            .sort("created_at", -1)
+            .limit(max(int(history_limit), 1))
+        )
+        history = await history_cursor.to_list(length=None)
+
+        period_points: Optional[int] = None
+        if period_start is not None:
+            pipeline = [
+                {
+                    "$match": {
+                        "username": username,
+                        "event_type": "points",
+                        "created_at": {"$gte": _ensure_timezone(period_start)},
+                    }
+                },
+                {"$group": {"_id": None, "points": {"$sum": "$points"}}},
+            ]
+            aggregation = await self._history.aggregate(pipeline).to_list(length=None)
+            if aggregation:
+                period_points = int(aggregation[0].get("points", 0) or 0)
+
+        breakdown = await self.get_user_point_breakdown(username)
+
+        achievement_events = [
+            event
+            for event in history
+            if event.get("event_type") == "achievement"
+        ]
+
+        return {
+            "username": username,
+            "total_points": int(user_doc.get("reward_points", 0) or 0),
+            "achievements": user_doc.get("achievements", []),
+            "history": history,
+            "period_points": period_points,
+            "breakdown": breakdown,
+            "achievement_events": achievement_events,
+        }
+
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
+    @staticmethod
+    def compute_period_start(period: str) -> Optional[datetime]:
+        """Restituisce l'inizio del periodo richiesto."""
+
+        normalized = (period or "").strip().lower()
+        now = datetime.now(timezone.utc)
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        if normalized in {"", "all", "totale", "sempre", "overall"}:
+            return None
+        if normalized in {"day", "daily", "giorno", "giornaliera"}:
+            return today
+        if normalized in {"week", "weekly", "settimana", "settimanale"}:
+            start_of_week = today - timedelta(days=today.weekday())
+            return start_of_week
+        if normalized in {"month", "monthly", "mese", "mensile"}:
+            return today.replace(day=1)
+
+        return None


### PR DESCRIPTION
## Summary
- Introduced a RewardsRepository with reward history tracking and rewrote the RewardService to support dynamic achievements, additional point types and admin notifications.
- Added leaderboard and progress commands plus scheduled weekly/monthly leaderboard pushes wired into the NotificationService.
- Updated application wiring and help content so the new reward features are documented and exposed to users.
- Ensure the RewardsRepository dataclass exposes slot fields for the user and history collections so initialization succeeds when slots are enabled.

## Testing
- python -m compileall services/rewards_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68cbfd0ada348323b950599288b1d817