### PR TITLE
Fix RewardService timezone initialization under dataclass slots

### DIFF
--- a/handlers/rewards.py
+++ b/handlers/rewards.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from aiogram import Router, types
@@ -17,6 +17,7 @@ class RewardHandlers:
 
     reward_service: RewardService
     logger: Any
+    router: Router = field(init=False)
 
     def __post_init__(self) -> None:
         self.router = Router()

--- a/reward_service.py
+++ b/reward_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 from zoneinfo import ZoneInfo
@@ -27,6 +27,11 @@ class RewardService:
     repository: RewardsRepository
     notification_service: Optional[EnhancedNotificationService] = None
     logger: Any = None
+    _local_tz: ZoneInfo = field(init=False, repr=False)
+    POINTS_CONFIG: Dict[str, Dict[str, Any]] = field(init=False)
+    POINT_TYPE_ALIASES: Dict[str, str] = field(init=False)
+    _period_aliases: Dict[str, Dict[str, Any]] = field(init=False, repr=False)
+    ACHIEVEMENTS: Dict[str, Dict[str, Any]] = field(init=False)
 
     def __post_init__(self) -> None:
         self.logger = self.logger or logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add explicit dataclass fields for RewardService configuration data so slots instances can initialize correctly
- declare the RewardHandlers router attribute to avoid AttributeError when slots are enabled

## Testing
- python -m compileall reward_service.py handlers/rewards.py

------
https://chatgpt.com/codex/tasks/task_e_68cc1bc90e948323912d63b325a0cdea