### PR TITLE
Integrate reward and statistics services with bot lifecycle

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,6 +38,7 @@ except ImportError as exc:  # pragma: no cover - il progetto può funzionare sen
     MIDDLEWARE_AVAILABLE = False
 
 from reward_service import RewardService
+from statistics_service import StatisticsService
 from services.identity_service import IdentityService
 from services.maintenance_service import MaintenanceService
 from services.mission_service import MissionService
@@ -70,6 +71,7 @@ identity_service: Optional[IdentityService] = None
 maintenance_service: Optional[MaintenanceService] = None
 mission_service: Optional[MissionService] = None
 reward_service: Optional[RewardService] = None
+statistics_service: Optional[StatisticsService] = None
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +152,12 @@ identity_service = IdentityService(
     logger=logger,
 )
 
+reward_service = RewardService(
+    repository=rewards_repository,
+    notification_service=notification_service,
+    logger=logger,
+)
+
 maintenance_service = MaintenanceService(
     bot=bot,
     db_manager=db_manager,
@@ -157,6 +165,7 @@ maintenance_service = MaintenanceService(
     clan_id=CLAN_ID,
     wolvesville_api_key=WOLVESVILLE_API_KEY,
     admin_ids=ADMIN_IDS,
+    reward_service=reward_service,
     logger=logger,
 )
 
@@ -168,10 +177,11 @@ mission_service = MissionService(
     wolvesville_api_key=WOLVESVILLE_API_KEY,
     clan_id=CLAN_ID,
     logger=logger,
+    reward_service=reward_service,
 )
 
-reward_service = RewardService(
-    repository=rewards_repository,
+statistics_service = StatisticsService(
+    db_manager=db_manager,
     notification_service=notification_service,
     logger=logger,
 )
@@ -346,6 +356,7 @@ async def main() -> None:
         mission_service=mission_service,
         identity_service=identity_service,
         reward_service=reward_service,
+        statistics_service=statistics_service,
         profile_auto_sync_minutes=PROFILE_AUTO_SYNC_INTERVAL_MINUTES,
         logger=logger,
     )

--- a/bot_app/scheduler.py
+++ b/bot_app/scheduler.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from reward_service import RewardService
+from statistics_service import StatisticsService
 from services.identity_service import IdentityService
 from services.maintenance_service import MaintenanceService
 from services.mission_service import MissionService
@@ -18,6 +19,7 @@ def setup_scheduler(
     mission_service: MissionService,
     identity_service: IdentityService,
     reward_service: RewardService,
+    statistics_service: StatisticsService,
     profile_auto_sync_minutes: int,
     logger,
 ) -> AsyncIOScheduler:
@@ -90,6 +92,34 @@ def setup_scheduler(
         hour=9,
         minute=5,
         timezone="Europe/Rome",
+    )
+
+    scheduler.add_job(
+        statistics_service.publish_weekly_donation_report,
+        "cron",
+        day_of_week="mon",
+        hour=8,
+        minute=30,
+        timezone="Europe/Rome",
+    )
+
+    scheduler.add_job(
+        statistics_service.publish_monthly_donation_report,
+        "cron",
+        day=1,
+        hour=8,
+        minute=45,
+        timezone="Europe/Rome",
+    )
+
+    scheduler.add_job(
+        reward_service.reset_all_points,
+        "cron",
+        day=1,
+        hour=9,
+        minute=30,
+        timezone="Europe/Rome",
+        kwargs={"reason": "reset mensile automatico"},
     )
 
     if not scheduler.running:

--- a/services/init.py
+++ b/services/init.py
@@ -7,10 +7,12 @@ from .identity_service import IdentityService
 from .maintenance_service import MaintenanceService
 from .mission_service import MissionService
 from .notification_service import NotificationService
+from statistics_service import StatisticsService
 
 __all__ = [
     "NotificationService",
     "IdentityService",
     "MaintenanceService",
     "MissionService",
+    "StatisticsService",
 ]

--- a/statistics_service.py
+++ b/statistics_service.py
@@ -1,32 +1,69 @@
-import matplotlib.pyplot as plt
-import seaborn as sns
-import pandas as pd
-from typing import Dict
+"""Utility di alto livello per generare e pubblicare statistiche del clan."""
+
+from __future__ import annotations
+
 import io
+import logging
+from typing import Dict, Optional, Sequence
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from aiogram import types
+
+from services.notification_service import (
+    EnhancedNotificationService,
+    NotificationType,
+)
+
 
 class StatisticsService:
-    def __init__(self, db_manager):
-        self.db = db_manager
-        
-    async def generate_donation_trends(self, days: int = 30) -> io.BytesIO:
-        """Genera un grafico temporale delle donazioni aggregate per valuta."""
+    """Raccoglie funzioni statistiche e di reporting per il clan."""
 
+    def __init__(
+        self,
+        db_manager,
+        *,
+        notification_service: Optional[EnhancedNotificationService] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self.db = db_manager
+        self.notification_service = notification_service
+        self.logger = logger or logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Helper
+    # ------------------------------------------------------------------
+    async def _load_donation_dataframe(self, days: int) -> pd.DataFrame:
         donations_data = await self.db.get_donation_time_series(days=days)
         df = pd.DataFrame(donations_data)
 
         if df.empty:
             df = pd.DataFrame(columns=["date", "gold", "gems", "donations"])
 
-        for column in ("gold", "gems", "donations"):
+        for column in ("date", "gold", "gems", "donations"):
             if column not in df:
                 df[column] = 0
 
-        if "date" in df:
-            try:
-                df["date"] = pd.to_datetime(df["date"], errors="coerce")
-            except Exception:  # pragma: no cover - conversione difensiva
-                pass
-            df = df.sort_values("date")
+        try:
+            df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        except Exception:  # pragma: no cover - conversione difensiva
+            pass
+
+        df = df.sort_values("date")
+        return df
+
+    @staticmethod
+    def _format_amount(value: float | int) -> str:
+        return f"{int(round(value)):,}".replace(",", ".")
+
+    # ------------------------------------------------------------------
+    # Donazioni
+    # ------------------------------------------------------------------
+    async def generate_donation_trends(self, days: int = 30) -> io.BytesIO:
+        """Genera un grafico temporale delle donazioni aggregate per valuta."""
+
+        df = await self._load_donation_dataframe(days)
 
         fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
 
@@ -48,6 +85,82 @@ class StatisticsService:
         plt.close()
 
         return buffer
+
+    async def publish_donation_report(self, *, days: int, title: str) -> None:
+        """Invia un report riassuntivo delle donazioni nel periodo indicato."""
+
+        if not self.notification_service:
+            self.logger.debug(
+                "Servizio notifiche non configurato: report donazioni %s saltato.",
+                title,
+            )
+            return
+
+        df = await self._load_donation_dataframe(days)
+        total_gold = int(df.get("gold", pd.Series(dtype=float)).sum()) if not df.empty else 0
+        total_gems = int(df.get("gems", pd.Series(dtype=float)).sum()) if not df.empty else 0
+        total_donations = int(df.get("donations", pd.Series(dtype=float)).sum()) if not df.empty else 0
+
+        top_donors: Sequence[Dict] = await self.db.get_top_donors(days=days, limit=5)
+
+        lines = [
+            f"📊 *Report {title} donazioni*",
+            "",
+            f"• Totale Oro: {self._format_amount(total_gold)}",
+            f"• Totale Gem: {self._format_amount(total_gems)}",
+            f"• Donazioni registrate: {self._format_amount(total_donations)}",
+        ]
+
+        if top_donors:
+            lines.append("")
+            lines.append("🥇 Top donatori:")
+            for index, donor in enumerate(top_donors, start=1):
+                username = donor.get("username", "Sconosciuto")
+                donor_total = donor.get("total_amount", 0) or 0
+                gold = donor.get("total_gold", 0) or 0
+                gems = donor.get("total_gems", 0) or 0
+                lines.append(
+                    (
+                        f"{index}. *{username}* — {self._format_amount(donor_total)} tot. "
+                        f"({self._format_amount(gold)} oro / {self._format_amount(gems)} gem)"
+                    )
+                )
+
+        caption = "\n".join(lines).strip()
+
+        channel_id = getattr(self.notification_service, "admin_channel_id", None)
+
+        try:
+            buffer = await self.generate_donation_trends(days=days)
+            if channel_id:
+                buffer.seek(0)
+                photo = types.BufferedInputFile(
+                    buffer.read(), filename="donation_report.png"
+                )
+                await self.notification_service.bot.send_photo(
+                    chat_id=channel_id,
+                    photo=photo,
+                    caption=caption,
+                    parse_mode="Markdown",
+                )
+                return
+        except Exception as exc:  # pragma: no cover - log difensivo
+            self.logger.warning("Invio grafico donazioni fallito: %s", exc)
+
+        try:
+            await self.notification_service.send_admin_notification(
+                caption,
+                NotificationType.INFO,
+                disable_rate_limit=True,
+            )
+        except Exception as exc:  # pragma: no cover - log difensivo
+            self.logger.error("Invio report donazioni fallito: %s", exc)
+
+    async def publish_weekly_donation_report(self) -> None:
+        await self.publish_donation_report(days=7, title="settimanale")
+
+    async def publish_monthly_donation_report(self) -> None:
+        await self.publish_donation_report(days=30, title="mensile")
 
     async def generate_participation_stats(self) -> Dict:
         """Genera statistiche partecipazione missioni"""


### PR DESCRIPTION
## Summary
- instantiate RewardService and the new StatisticsService during startup and wire them into maintenance and mission flows so ledger syncs and mission processing award points automatically
- extend the statistics tooling and scheduler to publish weekly/monthly donation reports and trigger the monthly reward reset via NotificationService
- add repository and service support for resetting reward points while notifying admins

## Testing
- python -m compileall bot.py bot_app services statistics_service.py reward_service.py

------
https://chatgpt.com/codex/tasks/task_e_68cd0020c85483239cc98ca389c2ce7e