### PR TITLE
Split /membri list into per-member messages

### DIFF
--- a/services/member_list_service.py
+++ b/services/member_list_service.py
@@ -28,22 +28,33 @@ class MemberListService:
     def __post_init__(self) -> None:
         self._lock = asyncio.Lock()
 
-    async def send_member_list(self, message: types.Message) -> types.Message:
+    async def send_member_list(self, message: types.Message) -> List[types.Message]:
         """Invia la lista dei membri nella chat del messaggio fornito."""
 
         chat_id = message.chat.id
         thread_id = getattr(message, "message_thread_id", None)
 
         async with self._lock:
-            text = await self._build_member_list_text()
+            messages_payload = await self._build_member_messages()
             await self._remove_previous_message(chat_id, thread_id)
-            sent_message = await message.answer(text)
-            await self.db_manager.upsert_member_list_message(
-                chat_id,
-                sent_message.message_id,
-                message_thread_id=thread_id,
-            )
-            return sent_message
+            sent_messages: List[types.Message] = []
+            for index, text in enumerate(messages_payload):
+                sent = await message.answer(text)
+                sent_messages.append(sent)
+                if index + 1 < len(messages_payload):
+                    await asyncio.sleep(0.05)
+
+            message_ids = [sent.message_id for sent in sent_messages]
+            if message_ids:
+                await self.db_manager.upsert_member_list_message(
+                    chat_id,
+                    message_ids,
+                    message_thread_id=thread_id,
+                )
+            else:
+                await self.db_manager.delete_member_list_message(chat_id, thread_id)
+
+            return sent_messages
 
     async def refresh_member_lists(self) -> None:
         """Rigenera la lista per tutte le chat in cui è stata pubblicata."""
@@ -53,88 +64,130 @@ class MemberListService:
             if not stored_messages:
                 return
 
-            text = await self._build_member_list_text()
+            messages_payload = await self._build_member_messages()
             for entry in stored_messages:
                 chat_id = entry.get("chat_id")
-                message_id = entry.get("message_id")
                 thread_id = entry.get("message_thread_id")
+                stored_message_ids: List[int] = []
 
-                if chat_id is None or message_id is None:
+                raw_ids = entry.get("message_ids")
+                if isinstance(raw_ids, (list, tuple)):
+                    for value in raw_ids:
+                        if isinstance(value, int):
+                            stored_message_ids.append(value)
+
+                legacy_message_id = entry.get("message_id")
+                if isinstance(legacy_message_id, int) and legacy_message_id not in stored_message_ids:
+                    stored_message_ids.insert(0, legacy_message_id)
+
+                if stored_message_ids:
+                    stored_message_ids = list(dict.fromkeys(stored_message_ids))
+
+                if chat_id is None or not stored_message_ids:
                     continue
 
                 should_remove_entry = False
-                try:
-                    await self.bot.delete_message(chat_id, message_id)
-                except TelegramForbiddenError:
-                    should_remove_entry = True
-                    self.logger.info(
-                        "Impossibile aggiornare la lista membri in %s: accesso negato", chat_id
-                    )
-                except TelegramBadRequest as exc:
-                    if "message to delete not found" in str(exc):
-                        should_remove_entry = False
-                    else:
-                        self.logger.debug(
-                            "Messaggio lista membri non eliminato (%s): %s",
+                remove_record = False
+                for stored_id in stored_message_ids:
+                    try:
+                        await self.bot.delete_message(chat_id, stored_id)
+                    except TelegramForbiddenError:
+                        should_remove_entry = True
+                        self.logger.info(
+                            "Impossibile aggiornare la lista membri in %s: accesso negato", chat_id
+                        )
+                        break
+                    except TelegramBadRequest as exc:
+                        if "message to delete not found" in str(exc):
+                            remove_record = True
+                        else:
+                            self.logger.debug(
+                                "Messaggio lista membri non eliminato (%s): %s",
+                                chat_id,
+                                exc,
+                            )
+                    except Exception as exc:  # pragma: no cover - log difensivo
+                        self.logger.warning(
+                            "Errore durante l'eliminazione della lista membri in %s: %s",
                             chat_id,
                             exc,
                         )
-                except Exception as exc:  # pragma: no cover - log difensivo
-                    self.logger.warning(
-                        "Errore durante l'eliminazione della lista membri in %s: %s",
-                        chat_id,
-                        exc,
-                    )
+
+                if remove_record:
+                    await self.db_manager.delete_member_list_message(chat_id, thread_id)
 
                 if should_remove_entry:
                     await self.db_manager.delete_member_list_message(chat_id, thread_id)
                     continue
 
-                try:
-                    sent = await self.bot.send_message(
-                        chat_id,
-                        text,
-                        message_thread_id=thread_id,
-                    )
-                except TelegramForbiddenError:
-                    await self.db_manager.delete_member_list_message(chat_id, thread_id)
-                    self.logger.info(
-                        "Impossibile inviare la nuova lista membri in %s: accesso negato",
-                        chat_id,
-                    )
+                sent_messages: List[types.Message] = []
+                for index, text in enumerate(messages_payload):
+                    try:
+                        sent = await self.bot.send_message(
+                            chat_id,
+                            text,
+                            message_thread_id=thread_id,
+                        )
+                    except TelegramForbiddenError:
+                        await self.db_manager.delete_member_list_message(chat_id, thread_id)
+                        self.logger.info(
+                            "Impossibile inviare la nuova lista membri in %s: accesso negato",
+                            chat_id,
+                        )
+                        should_remove_entry = True
+                        break
+                    except Exception as exc:  # pragma: no cover - log difensivo
+                        await self.db_manager.delete_member_list_message(chat_id, thread_id)
+                        self.logger.warning(
+                            "Errore durante l'invio della lista membri aggiornata in %s: %s",
+                            chat_id,
+                            exc,
+                        )
+                        should_remove_entry = True
+                        break
+
+                    sent_messages.append(sent)
+                    if index + 1 < len(messages_payload):
+                        await asyncio.sleep(0.05)
+
+                if should_remove_entry:
+                    for sent in sent_messages:
+                        try:
+                            await self.bot.delete_message(chat_id, sent.message_id)
+                        except Exception:  # pragma: no cover - clean-up best effort
+                            pass
                     continue
-                except Exception as exc:  # pragma: no cover - log difensivo
-                    self.logger.warning(
-                        "Errore durante l'invio della lista membri aggiornata in %s: %s",
-                        chat_id,
-                        exc,
-                    )
+
+                message_ids = [sent.message_id for sent in sent_messages]
+                if not message_ids:
+                    await self.db_manager.delete_member_list_message(chat_id, thread_id)
                     continue
 
                 await self.db_manager.upsert_member_list_message(
                     chat_id,
-                    sent.message_id,
+                    message_ids,
                     message_thread_id=thread_id,
                 )
                 await asyncio.sleep(0.2)
 
-    async def _build_member_list_text(self) -> str:
+    async def _build_member_messages(self) -> List[str]:
         entries = await self._collect_member_entries()
         if not entries:
-            return (
+            return [
                 "📋 <b>Lista membri del clan</b>\n"
                 "Nessun membro è stato trovato al momento."
-            )
+            ]
 
-        lines = ["📋 <b>Lista membri del clan</b>", ""]
+        messages: List[str] = []
         for index, entry in enumerate(entries, start=1):
+            prefix = "📋 <b>Lista membri del clan</b>\n" if index == 1 else ""
             line = (
-                f"{index}. Nome in gioco: {entry['game_name']} "
-                f"Nome telegram: {entry['telegram_name']} "
+                f"{index}. Game Name: {entry['game_name']} | "
+                f"Username: {entry['telegram_name']} | "
                 f"tag telegram(se presente): {entry['telegram_tag']}"
             )
-            lines.append(line)
-        return "\n".join(lines)
+            messages.append(f"{prefix}{line}")
+        return messages
 
     async def _collect_member_entries(self) -> List[Dict[str, str]]:
         members = await self._fetch_clan_members()
@@ -206,24 +259,50 @@ class MemberListService:
         if not existing:
             return
 
-        message_id = existing.get("message_id")
-        if not message_id:
+        message_ids: List[int] = []
+        raw_ids = existing.get("message_ids")
+        if isinstance(raw_ids, (list, tuple)):
+            for value in raw_ids:
+                if isinstance(value, int):
+                    message_ids.append(value)
+
+        legacy_message_id = existing.get("message_id")
+        if isinstance(legacy_message_id, int) and legacy_message_id not in message_ids:
+            message_ids.insert(0, legacy_message_id)
+
+        if message_ids:
+            message_ids = list(dict.fromkeys(message_ids))
+
+        if not message_ids:
             await self.db_manager.delete_member_list_message(chat_id, message_thread_id)
             return
 
-        try:
-            await self.bot.delete_message(chat_id, message_id)
-        except TelegramForbiddenError:
-            await self.db_manager.delete_member_list_message(chat_id, message_thread_id)
-        except TelegramBadRequest as exc:
-            if "message to delete not found" in str(exc):
+        remove_record = False
+        for stored_id in message_ids:
+            try:
+                await self.bot.delete_message(chat_id, stored_id)
+            except TelegramForbiddenError:
                 await self.db_manager.delete_member_list_message(chat_id, message_thread_id)
-        except Exception as exc:  # pragma: no cover - log difensivo
-            self.logger.debug(
-                "Impossibile rimuovere il vecchio messaggio della lista membri in %s: %s",
-                chat_id,
-                exc,
-            )
+                return
+            except TelegramBadRequest as exc:
+                if "message to delete not found" in str(exc):
+                    remove_record = True
+                else:
+                    self.logger.debug(
+                        "Impossibile rimuovere il messaggio %s della lista membri in %s: %s",
+                        stored_id,
+                        chat_id,
+                        exc,
+                    )
+            except Exception as exc:  # pragma: no cover - log difensivo
+                self.logger.debug(
+                    "Impossibile rimuovere il vecchio messaggio della lista membri in %s: %s",
+                    chat_id,
+                    exc,
+                )
+
+        if remove_record:
+            await self.db_manager.delete_member_list_message(chat_id, message_thread_id)
 
     @staticmethod
     def _escape(value: str) -> str:


### PR DESCRIPTION
## Summary
- update the member list service to send one message per clan member in the requested format and track the posted message ids as a batch
- adjust the refresh workflow to delete and recreate all stored messages while cleaning up on failures
- extend the Mongo manager to persist arrays of message ids for the member list records

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd30e50b6c8323a53a673502baf62f