### PR TITLE
Handle Telegram flood limits when sending member list

### DIFF
--- a/services/member_list_service.py
+++ b/services/member_list_service.py
@@ -6,11 +6,15 @@ import asyncio
 import html
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 
 import aiohttp
 from aiogram import Bot, types
-from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+from aiogram.exceptions import (
+    TelegramBadRequest,
+    TelegramForbiddenError,
+    TelegramRetryAfter,
+)
 
 from services.db_manager import MongoManager
 
@@ -24,6 +28,9 @@ class MemberListService:
     wolvesville_api_key: str
     clan_id: str
     logger: logging.Logger
+
+    _MESSAGE_DELAY_SECONDS = 1.05
+    _RETRY_AFTER_PADDING = 0.1
 
     def __post_init__(self) -> None:
         self._lock = asyncio.Lock()
@@ -39,11 +46,11 @@ class MemberListService:
             await self._remove_previous_message(chat_id, thread_id)
             sent_messages: List[types.Message] = []
             for index, text in enumerate(messages_payload):
-                sent = await message.answer(text, parse_mode="HTML")
-                sent = await message.answer(text)
+                send_operation = lambda text=text: message.answer(text, parse_mode="HTML")
+                sent = await self._send_with_retry(send_operation)
                 sent_messages.append(sent)
                 if index + 1 < len(messages_payload):
-                    await asyncio.sleep(0.05)
+                    await asyncio.sleep(self._MESSAGE_DELAY_SECONDS)
 
             message_ids = [sent.message_id for sent in sent_messages]
             if message_ids:
@@ -124,12 +131,13 @@ class MemberListService:
                 sent_messages: List[types.Message] = []
                 for index, text in enumerate(messages_payload):
                     try:
-                        sent = await self.bot.send_message(
+                        send_operation = lambda text=text: self.bot.send_message(
                             chat_id,
                             text,
                             parse_mode="HTML",
                             message_thread_id=thread_id,
                         )
+                        sent = await self._send_with_retry(send_operation)
                     except TelegramForbiddenError:
                         await self.db_manager.delete_member_list_message(chat_id, thread_id)
                         self.logger.info(
@@ -150,7 +158,7 @@ class MemberListService:
 
                     sent_messages.append(sent)
                     if index + 1 < len(messages_payload):
-                        await asyncio.sleep(0.05)
+                        await asyncio.sleep(self._MESSAGE_DELAY_SECONDS)
 
                 if should_remove_entry:
                     for sent in sent_messages:
@@ -188,11 +196,6 @@ class MemberListService:
                 f"{index}. Game Name: {entry['game_name']} | "
                 f"Username: {entry['telegram_name']} | "
                 f"tag telegram: {contact}"
-            line = (
-                f"{index}. Game Name: {entry['game_name']} | "
-                f"Username: {entry['telegram_name']} | "
-                f"tag telegram: {entry['telegram_contact']}"
-                f"tag telegram(se presente): {entry['telegram_tag']}"
             )
             messages.append(f"{prefix}{line}")
         return messages
@@ -228,9 +231,6 @@ class MemberListService:
                 telegram_name = "non collegato"
                 telegram_contact = "—"
                 telegram_tag = "—"
-            else:
-                telegram_name = "non collegato"
-                telegram_contact = "—"
 
             entries.append(
                 {
@@ -322,6 +322,21 @@ class MemberListService:
 
         if remove_record:
             await self.db_manager.delete_member_list_message(chat_id, message_thread_id)
+
+    async def _send_with_retry(
+        self, operation: Callable[[], Awaitable[types.Message]]
+    ) -> types.Message:
+        while True:
+            try:
+                return await operation()
+            except TelegramRetryAfter as exc:
+                delay = float(exc.retry_after) + self._RETRY_AFTER_PADDING
+                delay = max(delay, self._MESSAGE_DELAY_SECONDS)
+                self.logger.info(
+                    "Limite di invio Telegram raggiunto, attesa di %.2f secondi",
+                    delay,
+                )
+                await asyncio.sleep(delay)
 
     @staticmethod
     def _escape(value: str) -> str:


### PR DESCRIPTION
## Summary
- Introduce reusable throttling helpers that catch `TelegramRetryAfter` and wait at least one second between per-member sends.
- Update member list rendering to send each HTML-formatted message once with the cleaned contact fallback values.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd484920b883239a9b79d7076cf490