### PR TITLE
Add mission cost message and restrict skip command usage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -237,6 +237,7 @@ register_user_flow_handlers(
     wolvesville_api_key=WOLVESVILLE_API_KEY,
     clan_id=CLAN_ID,
     skip_image_path=SKIP_IMAGE_PATH,
+    owner_id=OWNER_CHAT_ID,
     admin_ids=ADMIN_IDS,
     authorized_groups=AUTHORIZED_GROUPS,
     schedule_admin_notification=schedule_admin_notification,

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Iterable, Sequence
+from typing import Callable, Iterable, Optional, Sequence
 
 from aiogram import Bot, Dispatcher
 
@@ -36,6 +36,7 @@ def register_user_flow_handlers(
     wolvesville_api_key: str,
     clan_id: str,
     skip_image_path: str,
+    owner_id: Optional[int],
     admin_ids: Sequence[int],
     authorized_groups: Sequence[int],
     schedule_admin_notification: Callable[..., None],
@@ -50,6 +51,8 @@ def register_user_flow_handlers(
         wolvesville_api_key=wolvesville_api_key,
         skip_image_path=skip_image_path,
         logger=logger,
+        authorized_group_ids=authorized_groups,
+        owner_id=owner_id,
     )
 
     balances_handlers = BalancesHandlers(

--- a/handlers/missions.py
+++ b/handlers/missions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Iterable, Optional, Set
 
 import aiohttp
 from aiogram import Router, types
@@ -27,11 +28,17 @@ class MissionHandlers:
         wolvesville_api_key: str,
         skip_image_path: str,
         logger,
+        authorized_group_ids: Optional[Iterable[int]] = None,
+        owner_id: Optional[int] = None,
     ) -> None:
         self.clan_id = clan_id
         self.wolvesville_api_key = wolvesville_api_key
         self.skip_image_path = skip_image_path
         self.logger = logger
+        self.authorized_group_ids: Set[int] = {
+            int(chat_id) for chat_id in authorized_group_ids or []
+        }
+        self.owner_id = owner_id
 
         self.router = Router()
         self.router.callback_query.register(
@@ -41,20 +48,24 @@ class MissionHandlers:
     async def start_flow(self, message: types.Message, state: FSMContext) -> None:
         """Present the mission menu with skip/skin options."""
 
-        keyboard = InlineKeyboardMarkup(
-            inline_keyboard=[
-                [
-                    InlineKeyboardButton(
-                        text="Skin",
-                        callback_data=MissionCallback(action="skin").pack(),
-                    ),
-                    InlineKeyboardButton(
-                        text="Skip",
-                        callback_data=MissionCallback(action="skip").pack(),
-                    ),
-                ]
-            ]
-        )
+        from_user = message.from_user.id if message.from_user else None
+        show_skip = self._is_skip_allowed(message.chat, from_user)
+
+        row = [
+            InlineKeyboardButton(
+                text="Skin",
+                callback_data=MissionCallback(action="skin").pack(),
+            )
+        ]
+        if show_skip:
+            row.append(
+                InlineKeyboardButton(
+                    text="Skip",
+                    callback_data=MissionCallback(action="skip").pack(),
+                )
+            )
+
+        keyboard = InlineKeyboardMarkup(inline_keyboard=[row])
         await message.answer("Missioni", reply_markup=keyboard)
 
     async def handle_mission_callback(
@@ -75,6 +86,28 @@ class MissionHandlers:
         else:
             await self._handle_skins(callback)
 
+    def _is_skip_allowed(
+        self,
+        chat: Optional[types.Chat],
+        user_id: Optional[int],
+    ) -> bool:
+        if chat is None:
+            return False
+
+        chat_type = getattr(chat, "type", "")
+        chat_id = getattr(chat, "id", None)
+
+        if chat_type == "private":
+            return user_id is not None and user_id == self.owner_id
+
+        if chat_id is None:
+            return False
+
+        if self.authorized_group_ids:
+            return chat_id in self.authorized_group_ids
+
+        return chat_type in {"group", "supergroup"}
+
     async def _handle_skip(self, callback: types.CallbackQuery) -> None:
         url = (
             f"https://api.wolvesville.com/clans/{self.clan_id}/quests/active/skipWaitingTime"
@@ -82,6 +115,21 @@ class MissionHandlers:
 
         user_id = callback.from_user.id
         username = callback.from_user.username or callback.from_user.first_name
+
+        if not self._is_skip_allowed(callback.message.chat, user_id):
+            warning_text = (
+                "❌ Il comando /skip missione può essere utilizzato solo nel gruppo del clan."
+                " In privato è consentito esclusivamente all'owner."
+            )
+            if self.owner_id is not None and user_id != self.owner_id:
+                chat_id = callback.message.chat.id if callback.message else "unknown"
+                self.logger.warning(
+                    "Skip command denied for user %s in chat %s", user_id, chat_id
+                )
+            await callback.answer("Accesso negato", show_alert=True)
+            await callback.message.answer(warning_text)
+            return
+
         self.logger.info(
             "Skip command requested by user %s (%s)",
             user_id,

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -768,6 +768,38 @@ class MissionService:
         )
         await state.set_state(MissionStates.CONFIRMING_PARTICIPANTS)
 
+    def _build_mission_cost_summary(
+        self,
+        mission: Optional[Dict[str, Any]],
+        participant_count: int,
+    ) -> str:
+        is_gem_mission = bool(mission and mission.get("purchasableWithGems", False))
+        cost_per_participant = 0
+
+        if is_gem_mission:
+            if participant_count > 7:
+                cost_per_participant = 140
+            elif 5 <= participant_count <= 7:
+                cost_per_participant = 150
+            else:
+                cost_per_participant = 0
+        else:
+            cost_per_participant = 500 if participant_count > 0 else 0
+
+        if cost_per_participant == 0:
+            return "💰 Costo missione: Nessun costo aggiuntivo previsto."
+
+        total_cost = cost_per_participant * participant_count
+        currency_total = "Gemme" if is_gem_mission else "Oro"
+        currency_per = "gemme" if is_gem_mission else "oro"
+        participant_label = "partecipante" if participant_count == 1 else "partecipanti"
+
+        return (
+            "💰 Costo missione: "
+            f"{total_cost} {currency_total} totali "
+            f"({cost_per_participant} {currency_per} per {participant_label})."
+        )
+
     async def enable_votes_callback(
         self, callback: types.CallbackQuery, state: FSMContext
     ) -> None:
@@ -784,14 +816,26 @@ class MissionService:
             data = await state.get_data()
             mission_player_ids_raw = data.get("mission_player_ids", [])
             selected_mission_id = data.get("selected_mission_id")
+            available_missions = data.get("available_missions", [])
+
+            mission_info: Optional[Dict[str, Any]] = None
+            if isinstance(available_missions, list):
+                for mission in available_missions:
+                    if not isinstance(mission, dict):
+                        continue
+                    mission_id_candidate = str(mission.get("id"))
+                    if mission_id_candidate == selected_mission_id:
+                        mission_info = mission
+                        break
 
             mission_player_ids = [str(pid) for pid in mission_player_ids_raw]
             mission_player_ids = list(dict.fromkeys(mission_player_ids))
+            participant_count = len(mission_player_ids)
 
             self.logger.info(
                 "Missione %s: abilito %s partecipanti dal voto",
                 selected_mission_id,
-                len(mission_player_ids),
+                participant_count,
             )
 
             if not mission_player_ids:
@@ -899,13 +943,24 @@ class MissionService:
                     ) as resp:
                         claim_body = await resp.text()
                         if resp.status in [200, 201, 204]:
-                            await callback.message.answer(
-                                "🚀 Missione avviata con successo."
+                            cost_summary = self._build_mission_cost_summary(
+                                mission_info,
+                                participant_count,
                             )
+                            message_lines = [
+                                "🚀 Missione avviata con successo.",
+                                cost_summary,
+                            ]
+                            await callback.message.answer("\n".join(message_lines))
                             self.logger.info(
                                 "Missione %s avviata con successo: %s",
                                 selected_mission_id,
                                 claim_body,
+                            )
+                            self.logger.info(
+                                "Missione %s costo stimato: %s",
+                                selected_mission_id,
+                                cost_summary,
                             )
                         else:
                             self.logger.error(


### PR DESCRIPTION
## Summary
- append a cost summary when launching a mission based on the mission type and enabled participants
- restrict the skip mission action to clan groups (allowing only the owner in private chats) and hide the skip shortcut when unavailable
- pass owner and group configuration into the mission handlers for the new permissions check

## Testing
- python -m compileall handlers services bot.py

------
https://chatgpt.com/codex/tasks/task_e_68e633bcb4e48323bbf148e7976c89db