### PR TITLE
Persist clan topic for mission announcements

### DIFF
--- a/services/db_manager.py
+++ b/services/db_manager.py
@@ -33,6 +33,9 @@ class MongoManager:
         self.member_list_messages_col: AsyncIOMotorCollection = self._database[
             "member_list_messages"
         ]
+        self.mission_context_col: AsyncIOMotorCollection = self._database[
+            "mission_context"
+        ]
 
     @property
     def database(self) -> AsyncIOMotorDatabase:
@@ -1172,6 +1175,46 @@ class MongoManager:
             update_statement,
             upsert=True,
         )
+
+    async def get_mission_announcement_context(self) -> Optional[Dict[str, Any]]:
+        """Restituisce la chat e il topic utilizzati per gli annunci missione."""
+
+        document = await self.mission_context_col.find_one({"_id": "weekly_announcement"})
+        if not document:
+            return None
+
+        return {
+            "chat_id": document.get("chat_id"),
+            "message_thread_id": document.get("message_thread_id"),
+            "updated_at": document.get("updated_at"),
+        }
+
+    async def upsert_mission_announcement_context(
+        self,
+        *,
+        chat_id: int,
+        message_thread_id: Optional[int],
+    ) -> None:
+        """Aggiorna il contesto (chat/topic) usato per l'annuncio settimanale."""
+
+        payload: Dict[str, Any] = {
+            "chat_id": int(chat_id),
+            "message_thread_id": int(message_thread_id)
+            if message_thread_id is not None
+            else None,
+            "updated_at": datetime.now(timezone.utc),
+        }
+
+        await self.mission_context_col.update_one(
+            {"_id": "weekly_announcement"},
+            {"$set": payload},
+            upsert=True,
+        )
+
+    async def delete_mission_announcement_context(self) -> None:
+        """Rimuove il contesto salvato per gli annunci missione."""
+
+        await self.mission_context_col.delete_one({"_id": "weekly_announcement"})
 
     async def list_member_list_messages(self) -> List[Dict[str, Any]]:
         """Restituisce tutti i messaggi registrati per la lista membri."""

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -278,6 +278,84 @@ class MissionService:
 
         return event_id
 
+    async def capture_clan_context(self, message: types.Message) -> None:
+        """Memorizza chat e topic del clan per gli annunci automatici."""
+
+        chat = getattr(message, "chat", None)
+        if chat is None:
+            return
+
+        chat_type = getattr(chat, "type", "") or ""
+        if chat_type not in {"group", "supergroup"}:
+            return
+
+        chat_id = getattr(chat, "id", None)
+        if chat_id is None:
+            return
+
+        thread_id_raw = getattr(message, "message_thread_id", None)
+        thread_id: Optional[int]
+        try:
+            thread_id = int(thread_id_raw) if thread_id_raw is not None else None
+        except (TypeError, ValueError):
+            thread_id = None
+
+        self.clan_chat_id = int(chat_id)
+        self.clan_topic_id = thread_id
+
+        try:
+            await self.db_manager.upsert_mission_announcement_context(
+                chat_id=int(chat_id), message_thread_id=thread_id
+            )
+        except Exception as exc:  # pragma: no cover - log difensivo
+            self.logger.warning(
+                "Impossibile salvare il contesto missione: %s", exc
+            )
+
+    async def _ensure_clan_context(self) -> bool:
+        """Recupera da database la chat del clan se non è già nota."""
+
+        if self.clan_chat_id is not None:
+            return True
+
+        try:
+            record = await self.db_manager.get_mission_announcement_context()
+        except Exception as exc:  # pragma: no cover - log difensivo
+            self.logger.warning(
+                "Recupero contesto missione fallito: %s", exc
+            )
+            return False
+
+        if not record:
+            return False
+
+        chat_id = record.get("chat_id")
+        if chat_id is None:
+            return False
+
+        try:
+            self.clan_chat_id = int(chat_id)
+        except (TypeError, ValueError):
+            self.logger.warning(
+                "Chat ID non valido nel contesto missione salvato: %s", chat_id
+            )
+            return False
+
+        thread_id = record.get("message_thread_id")
+        if thread_id is None:
+            self.clan_topic_id = None
+        else:
+            try:
+                self.clan_topic_id = int(thread_id)
+            except (TypeError, ValueError):
+                self.logger.debug(
+                    "Topic ID non valido nel contesto missione salvato: %s",
+                    thread_id,
+                )
+                self.clan_topic_id = None
+
+        return True
+
     async def process_active_mission_auto(self) -> None:
         """Resolve the currently active mission, apply costs and store history."""
 
@@ -474,6 +552,9 @@ class MissionService:
 
     async def send_weekly_mission_skin(self) -> None:
         """Announce weekly missions and post the available skins."""
+
+        if self.clan_chat_id is None:
+            await self._ensure_clan_context()
 
         if self.clan_chat_id is None:
             self.logger.warning(
@@ -686,6 +767,8 @@ class MissionService:
     async def partecipanti_command(
         self, message: types.Message, state: FSMContext
     ) -> None:
+        await self.capture_clan_context(message)
+
         missions = await self.get_available_missions()
         if not missions:
             await message.answer("Nessuna missione disponibile al momento.")


### PR DESCRIPTION
## Summary
- add a MongoDB collection entry for mission announcement context so chat and topic IDs are stored
- capture the clan chat/thread when the Player Missione flow runs and persist it for later
- reload the saved context before the Monday auto-announcement so messages reach the right topic

## Testing
- python -m compileall services

------
https://chatgpt.com/codex/tasks/task_e_68e63c011fa48323b9c756cd7a8d7221